### PR TITLE
refactor(auth): remove organization login mutation and simplify login…

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -10,7 +10,7 @@ import { mainUrl } from '@/helpers/baseUrl';
 import Button from '../../../components/ui/Button-ant';
 import InputPassword from '@/components/ui/InputPassword';
 import Input from 'antd/es/input';
-import { useLoginMutation, useLoginOrganizationMutation } from '@/states/authentication';
+import { useLoginMutation } from '@/states/authentication';
 import { ClipLoader } from 'react-spinners';
 import { useAuthToken } from '@/hooks/use-auth-token';
 
@@ -75,7 +75,6 @@ const LoginForm: React.FC = () => {
   const returnUrl = searchParams.get('returnUrl') || '/home';
 
   const [login, { isLoading }] = useLoginMutation();
-  const [loginOrganization, { isLoading: isOrgLoading }] = useLoginOrganizationMutation();
   const { setToken, getToken } = useAuthToken();
   const { getTokenInfo, decodeToken } = useTokenInfo();
 
@@ -131,19 +130,7 @@ const LoginForm: React.FC = () => {
 
   const onSubmit = async (data: LoginFormInputs) => {
     try {
-
-      // Try organization login first, then fall back to regular login
-      let response;
-      let isOrganization = false;
-
-      try {
-        response = await loginOrganization(data).unwrap();
-        isOrganization = true;
-      } catch (orgError) {
-        response = await login(data).unwrap();
-        isOrganization = false;
-      }
-
+      const response = await login(data).unwrap();
       const { token, account } = response;
 
       setToken(token);
@@ -155,8 +142,7 @@ const LoginForm: React.FC = () => {
       }
 
       // Determine account type for appropriate messaging
-      const accountType = isOrganization ? 'organization' : (tokenInfo.accountType || 'user');
-      const entityType = accountType === 'organization' ? 'Organization' : 'User';
+      const accountType = tokenInfo.accountType || 'user';
 
       notification.success({
         message: 'Login Successful',
@@ -343,9 +329,9 @@ const LoginForm: React.FC = () => {
           htmlType="submit"
           type="primary"
           className="w-full !mt-4"
-          disabled={isLoading || isOrgLoading}
+          disabled={isLoading}
         >
-          {(isLoading || isOrgLoading) ? (
+          {isLoading ? (
             <div className="flex items-center justify-center">
               <ClipLoader color='#ffffff' size={20} />
               <span className="ml-2">Signing in...</span>
@@ -366,7 +352,7 @@ const LoginForm: React.FC = () => {
         icon={<GoogleOutlined />}
         className="w-full flex justify-center items-center bg-gray-100 border-gray-300 text-gray-700 hover:text-white"
         onClick={handleGoogleLogin}
-        disabled={isLoading || isOrgLoading}
+        disabled={isLoading}
       >
         Sign in with Google
       </Button>

--- a/app/home/transfer/amount/page.tsx
+++ b/app/home/transfer/amount/page.tsx
@@ -274,11 +274,6 @@ const AmountPage = () => {
       return;
     }
 
-    if (!selectedCategory) {
-      setError("Please select a transaction category");
-      return;
-    }
-
     // Validate constraints requirements for individual user transfers
     if (recipient.type !== 'organization' && applyConstraints && !selectedCategory) {
       setError("Please select a category when applying spending constraints");
@@ -477,59 +472,7 @@ const AmountPage = () => {
               </div>
             </div>
 
-            {/* Category Selection - Only show for individual users, not organizations */}
-            {recipient.type !== 'organization' && (
-              <div className="bg-white rounded-3xl p-6 mb-6 shadow-sm border border-gray-100">
-                <label className="block text-sm font-medium text-gray-700 mb-4">
-                  Select Category
-                </label>
-
-                {categoriesLoading ? (
-                  <div className="text-center py-4 text-gray-500">
-                    <div className="animate-pulse">Loading categories...</div>
-                  </div>
-                ) : categories.length === 0 ? (
-                  <div className="text-center py-4 text-gray-500">
-                    <p>No categories available</p>
-                    <button
-                      onClick={() => {
-                        setCategoriesLoading(true);
-                        getTransactionCategories()
-                          .then((response: any) => {
-                            if (response.data?.success && response.data?.data) {
-                              setCategories(response.data.data);
-                            }
-                          })
-                          .catch((err) => console.error('Retry failed:', err))
-                          .finally(() => setCategoriesLoading(false));
-                      }}
-                      className="mt-2 text-green-600 hover:text-green-700 text-sm font-medium"
-                    >
-                      Try Again
-                    </button>
-                  </div>
-                ) : (
-                  <div className="grid grid-cols-2 gap-3">
-                    {categories.map((category) => (
-                      <button
-                        key={category.id}
-                        onClick={() => {
-                          setSelectedCategory(category);
-                        }}
-                        className={`py-3 px-4 rounded-xl font-medium transition text-left ${selectedCategory?.id === category.id
-                          ? 'bg-green-600 text-white'
-                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                          }`}
-                      >
-                        {category.name}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-            )}
-
-            {/* Apply Constraints Toggle - Only show for individual users, not organizations */}
+            {/* Apply Constraints Toggle & Category - Only show for individual users, not organizations */}
             {recipient.type !== 'organization' && (
               <div className="bg-white rounded-3xl p-6 mb-6 shadow-sm border border-gray-100">
                 <div className="flex items-center justify-between">
@@ -552,6 +495,59 @@ const AmountPage = () => {
                     />
                   </button>
                 </div>
+
+                {/* Category Selection - only when constraints are enabled */}
+                {applyConstraints && (
+                  <div className="mt-4">
+                    <label className="block text-sm font-medium text-gray-700 mb-3">
+                      Select Category
+                    </label>
+
+                    {categoriesLoading ? (
+                      <div className="text-center py-4 text-gray-500">
+                        <div className="animate-pulse">Loading categories...</div>
+                      </div>
+                    ) : categories.length === 0 ? (
+                      <div className="text-center py-4 text-gray-500">
+                        <p>No categories available</p>
+                        <button
+                          onClick={() => {
+                            setCategoriesLoading(true);
+                            getTransactionCategories()
+                              .then((response: any) => {
+                                if (response.data?.success && response.data?.data) {
+                                  setCategories(response.data.data);
+                                }
+                              })
+                              .catch((err) => console.error('Retry failed:', err))
+                              .finally(() => setCategoriesLoading(false));
+                          }}
+                          className="mt-2 text-green-600 hover:text-green-700 text-sm font-medium"
+                        >
+                          Try Again
+                        </button>
+                      </div>
+                    ) : (
+                      <div className="grid grid-cols-2 gap-3">
+                        {categories.map((category) => (
+                          <button
+                            key={category.id}
+                            onClick={() => {
+                              setSelectedCategory(category);
+                            }}
+                            className={`py-3 px-4 rounded-xl font-medium transition text-left ${
+                              selectedCategory?.id === category.id
+                                ? 'bg-green-600 text-white'
+                                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                            }`}
+                          >
+                            {category.name}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
 
                 {/* Constraints Warning */}
                 {applyConstraints && (

--- a/states/authentication.ts
+++ b/states/authentication.ts
@@ -10,13 +10,6 @@ export const authenticationSlice = apiSlice.injectEndpoints({
                 body: credentials,
             }),
         }),
-        loginOrganization: builder.mutation({
-            query: (credentials) => ({
-                url: '/organizations/login',
-                method: 'POST',
-                body: credentials,
-            }),
-        }),
         registerUser: builder.mutation({
             query: (userData) => ({
                 url: '/users/register',
@@ -72,7 +65,6 @@ export const authenticationSlice = apiSlice.injectEndpoints({
 
 export const {
     useLoginMutation,
-    useLoginOrganizationMutation,
     useRegisterUserMutation,
     useRegisterOrganizationMutation,
     useVerifyOtpMutation,


### PR DESCRIPTION
Removed the organization login endpoint from the auth slice:
Deleted the loginOrganization mutation that was using url: '/organizations/login'.
Also removed useLoginOrganizationMutation from the exported hooks.

Category requirement logic:
Removed the unconditional check that blocked transfers when no category was selected.
Now a category is only required when Apply Spending Constraints is enabled for individual recipients: