### PR TITLE
feat: chat UX — resizable input, emoji picker, date separators, sound/vibration notifications

### DIFF
--- a/components/chat/chat-area.tsx
+++ b/components/chat/chat-area.tsx
@@ -8,6 +8,52 @@ import MessageItem from "./message-item"
 import MessageInput from "./message-input"
 import type { Conversation, Message, LegacyMessage } from "@/types/chat.types"
 
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+
+function getMidnight(date: Date): number {
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime()
+}
+
+function formatDateLabel(date: Date): string {
+    const now = new Date()
+    const todayMs     = getMidnight(now)
+    const yesterdayMs = todayMs - 86_400_000
+    const msgMs       = getMidnight(date)
+
+    if (msgMs === todayMs)     return "Today"
+    if (msgMs === yesterdayMs) return "Yesterday"
+
+    // e.g. "Friday, 20 March 2026"
+    return date.toLocaleDateString("en-GB", {
+        weekday: "long",
+        day:     "numeric",
+        month:   "long",
+        year:    "numeric",
+    })
+}
+
+function getMessageDate(message: Message | LegacyMessage): Date {
+    if ("createdAt" in message && message.createdAt) return new Date(message.createdAt)
+    if ("timestamp" in message && message.timestamp) return new Date(message.timestamp)
+    return new Date()
+}
+
+// ─── DateSeparator component ──────────────────────────────────────────────────
+
+function DateSeparator({ date }: { date: Date }) {
+    return (
+        <div className="flex items-center gap-3 my-5 px-1 select-none" aria-label={`Messages from ${formatDateLabel(date)}`}>
+            <div className="flex-1 h-px bg-gray-200 dark:bg-darkBorder-medium" />
+            <span className="text-xs sm:text-sm font-semibold text-gray-500 dark:text-gray-400 px-4 py-1.5 rounded-full bg-gray-100 dark:bg-darkBg-interactive border border-gray-200 dark:border-darkBorder-light whitespace-nowrap tracking-wide">
+                {formatDateLabel(date)}
+            </span>
+            <div className="flex-1 h-px bg-gray-200 dark:bg-darkBorder-medium" />
+        </div>
+    )
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
 interface ChatAreaProps {
     conversation: Conversation
     messages: Message[] | LegacyMessage[]
@@ -73,15 +119,30 @@ export default function ChatArea({
             </div>
 
             {/* Messages */}
-            <div className="flex-1 overflow-y-auto p-3 sm:p-4 space-y-4">
+            <div className="flex-1 overflow-y-auto p-3 sm:p-4">
                 {messages.length > 0 ? (
                     <>
-                        {messages.map((message) => (
-                            <MessageItem key={message.id} message={message} />
-                        ))}
+                        {(() => {
+                            let lastDateKey = ""
+                            return (messages as Array<Message | LegacyMessage>).map((message) => {
+                                const msgDate   = getMessageDate(message)
+                                const dateKey   = `${msgDate.getFullYear()}-${msgDate.getMonth()}-${msgDate.getDate()}`
+                                const showSep   = dateKey !== lastDateKey
+                                lastDateKey     = dateKey
+
+                                return (
+                                    <div key={message.id}>
+                                        {showSep && <DateSeparator date={msgDate} />}
+                                        <div className="mb-4">
+                                            <MessageItem message={message} />
+                                        </div>
+                                    </div>
+                                )
+                            })
+                        })()}
 
                         {typingUsers.length > 0 && (
-                            <div className="flex items-center gap-2 p-3 bg-white dark:bg-darkBg-card rounded-lg border border-gray-100 dark:border-darkBorder-light">
+                            <div className="flex items-center gap-2 p-3 bg-white dark:bg-darkBg-card rounded-lg border border-gray-100 dark:border-darkBorder-light mb-4">
                                 <div className="flex space-x-1">
                                     <div className="w-2 h-2 bg-brand-green dark:bg-brand-gold rounded-full animate-bounce" />
                                     <div
@@ -121,7 +182,7 @@ export default function ChatArea({
             </div>
 
             {/* Message Input */}
-            <div className="flex-shrink-0 bg-white dark:bg-darkBg-card border-t border-gray-100 dark:border-darkBorder-light">
+            <div className="flex-shrink-0">
                 <MessageInput />
             </div>
         </div>

--- a/components/chat/message-input.tsx
+++ b/components/chat/message-input.tsx
@@ -1,210 +1,318 @@
 "use client"
 
-import { useState, useRef, useEffect } from "react"
+import { useState, useRef, useEffect, useCallback } from "react"
+import dynamic from "next/dynamic"
+import type { EmojiClickData } from "emoji-picker-react"
 import { Button } from "@/components/ui/button"
 import { Send, Paperclip, Smile, ImageIcon } from "lucide-react"
 import OptionsDropdown from "./options-dropdown"
 import { toast } from "@/hooks/use-toast"
-import Input from "../ui/Input-ant"
 import { useChat } from "@/context/ChatContext"
+import { useTheme } from "@/context/ThemeContext"
 import MediaUploadModal from "./media-upload-modal"
 import { uploadMediaMessage } from "@/services/mediaService"
+
+const EmojiPicker = dynamic(() => import("emoji-picker-react"), { ssr: false })
+
+const MAX_HEIGHT = 160
+
+// CSS variable overrides injected into the emoji picker's host div
+const pickerVars = (isDark: boolean): React.CSSProperties => ({
+    // Background
+    "--epr-bg-color":                isDark ? "#0c2418"                  : "#ffffff",
+    "--epr-category-label-bg-color": isDark ? "#040f0c"                  : "#f9fafb",
+    // Search
+    "--epr-search-input-bg-color":   isDark ? "#0d1e15"                  : "#f3f4f6",
+    "--epr-search-input-text-color": isDark ? "#e5e7eb"                  : "#111827",
+    "--epr-search-border-color":     isDark ? "rgba(255,255,255,0.07)"   : "#e5e7eb",
+    // Text & icons
+    "--epr-text-color":              isDark ? "#d1d5db"                  : "#374151",
+    "--epr-category-icon-active-color": isDark ? "#00B512"               : "#00B512",
+    // Hover / highlight (brand-green tint)
+    "--epr-hover-color":             isDark ? "rgba(0,181,18,0.12)"      : "#f0fdf4",
+    "--epr-focus-bg-color":          isDark ? "rgba(0,181,18,0.08)"      : "#dcfce7",
+    "--epr-highlight-color":         "#00B512",
+    // Borders
+    "--epr-border-color":            isDark ? "rgba(255,255,255,0.06)"   : "#e5e7eb",
+    // Radius to match the app's rounded-2xl cards
+    "--epr-emoji-border-radius":     "10px",
+    "--epr-header-padding":          "8px 8px 0",
+} as React.CSSProperties)
 
 interface MessageInputProps {
     onSendMessage?: (message: string) => void
 }
 
 export default function MessageInput({ onSendMessage = () => { } }: MessageInputProps) {
-    const [messageText, setMessageText] = useState<string>("")
-    const [showOptions, setShowOptions] = useState<boolean>(false)
-    const [showMediaModal, setShowMediaModal] = useState<boolean>(false)
-    const [uploading, setUploading] = useState<boolean>(false)
-    const [uploadProgress, setUploadProgress] = useState<number>(0)
-    const dropdownRef = useRef<HTMLDivElement | null>(null)
+    const [messageText, setMessageText]     = useState<string>("")
+    const [showOptions, setShowOptions]     = useState<boolean>(false)
+    const [showEmojiPicker, setShowEmojiPicker] = useState<boolean>(false)
+    const [showMediaModal, setShowMediaModal]   = useState<boolean>(false)
+    const [uploading, setUploading]         = useState<boolean>(false)
+    const [uploadProgress, setUploadProgress]   = useState<number>(0)
+    const [cursorPos, setCursorPos]         = useState<number>(0)
+
+    const wrapperRef     = useRef<HTMLDivElement | null>(null)
+    const dropdownRef    = useRef<HTMLDivElement | null>(null)
+    const emojiPickerRef = useRef<HTMLDivElement | null>(null)
+    const emojiButtonRef = useRef<HTMLButtonElement | null>(null)
+    const textareaRef    = useRef<HTMLTextAreaElement | null>(null)
+
     const chat = useChat()
+    const { theme } = useTheme()
+    const isDark = theme === "dark"
+    const { activeChat, sendMessage: contextSendMessage, startTyping, stopTyping, isConnected, addMessage } = chat
 
-    const {
-        activeChat,
-        sendMessage: contextSendMessage,
-        startTyping,
-        stopTyping,
-        isConnected,
-        addMessage
-    } = chat
-
-    useEffect(() => {
-        const handleClickOutside = (event: MouseEvent) => {
-            if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-                setShowOptions(false)
-            }
-        }
-
-        document.addEventListener("mousedown", handleClickOutside)
-        return () => {
-            document.removeEventListener("mousedown", handleClickOutside)
-        }
+    // ── Auto-resize ───────────────────────────────────────────────────────────
+    const resizeTextarea = useCallback(() => {
+        const el = textareaRef.current
+        if (!el) return
+        el.style.height = "auto"
+        el.style.height = `${Math.min(el.scrollHeight, MAX_HEIGHT)}px`
+        el.style.overflowY = el.scrollHeight > MAX_HEIGHT ? "auto" : "hidden"
     }, [])
 
-    const handleSendMessage = () => {
-        if (messageText.trim()) {
-            if (contextSendMessage && activeChat) {
-                contextSendMessage(activeChat, messageText.trim())
-                // Stop typing indicator when sending
-                if (stopTyping) {
-                    stopTyping(activeChat)
-                }
-            } else {
-                // Fallback to legacy onSendMessage prop
-                onSendMessage(messageText)
-            }
+    useEffect(() => { resizeTextarea() }, [messageText, resizeTextarea])
 
-            setMessageText("")
-            toast({
-                title: "Message sent",
-                description: "Message sent successfully",
-            })
+    // ── Outside-click: close dropdown + emoji picker ──────────────────────────
+    useEffect(() => {
+        const handler = (e: MouseEvent) => {
+            if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+                setShowOptions(false)
+            }
+            if (
+                emojiPickerRef.current  && !emojiPickerRef.current.contains(e.target as Node) &&
+                emojiButtonRef.current  && !emojiButtonRef.current.contains(e.target as Node)
+            ) {
+                setShowEmojiPicker(false)
+            }
+        }
+        document.addEventListener("mousedown", handler)
+        return () => document.removeEventListener("mousedown", handler)
+    }, [])
+
+    // ── Save cursor position ──────────────────────────────────────────────────
+    const saveCursor = () => {
+        if (textareaRef.current) setCursorPos(textareaRef.current.selectionStart)
+    }
+
+    // ── Insert emoji at cursor ────────────────────────────────────────────────
+    const handleEmojiClick = (data: EmojiClickData) => {
+        const emoji  = data.emoji
+        const before = messageText.slice(0, cursorPos)
+        const after  = messageText.slice(cursorPos)
+        const newText = before + emoji + after
+        setMessageText(newText)
+        const newCursor = cursorPos + emoji.length
+        setCursorPos(newCursor)
+        requestAnimationFrame(() => {
+            if (textareaRef.current) {
+                textareaRef.current.focus()
+                textareaRef.current.setSelectionRange(newCursor, newCursor)
+            }
+        })
+    }
+
+    // ── Send ──────────────────────────────────────────────────────────────────
+    const handleSendMessage = useCallback(() => {
+        const text = messageText.trim()
+        if (!text) return
+        if (contextSendMessage && activeChat) {
+            contextSendMessage(activeChat, text)
+            if (stopTyping) stopTyping(activeChat)
+        } else {
+            onSendMessage(text)
+        }
+        setMessageText("")
+        setShowEmojiPicker(false)
+        if (textareaRef.current) {
+            textareaRef.current.style.height = "auto"
+            textareaRef.current.style.overflowY = "hidden"
+        }
+    }, [messageText, activeChat, contextSendMessage, stopTyping, onSendMessage])
+
+    // ── Textarea events ───────────────────────────────────────────────────────
+    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        const value = e.target.value
+        setMessageText(value)
+        setCursorPos(e.target.selectionStart)
+        if (activeChat && startTyping && stopTyping) {
+            if (value.trim()) startTyping(activeChat)
+            else stopTyping(activeChat)
         }
     }
 
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.key === "Escape") { setShowEmojiPicker(false); return }
+        if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); handleSendMessage() }
+    }
+
+    const handleBlur = () => {
+        saveCursor()
+        if (activeChat && stopTyping) stopTyping(activeChat)
+    }
+
+    // ── Attachments / Media ───────────────────────────────────────────────────
     const handleOptionSelect = (option: string) => {
         setShowOptions(false)
-        toast({
-            title: "Selected option",
-            description: option,
-        })
+        toast({ title: "Selected option", description: option })
     }
 
     const handleMediaUpload = async (file: File, caption: string) => {
         if (!activeChat) {
-            toast({
-                title: "Error",
-                description: "No active chat selected",
-                variant: "destructive"
-            })
+            toast({ title: "Error", description: "No active chat selected", variant: "destructive" })
             return
         }
-
-        setUploading(true)
-        setUploadProgress(0)
-
+        setUploading(true); setUploadProgress(0)
         try {
-            const result = await uploadMediaMessage(
-                activeChat,
-                file,
-                caption,
-                (progress) => {
-                    setUploadProgress(progress.percentage)
-                }
-            )
-
+            const result = await uploadMediaMessage(activeChat, file, caption, (p) => setUploadProgress(p.percentage))
             if (result.success && result.data) {
-                if (addMessage) {
-                    addMessage(result.data as any)
-                }
-
-                toast({
-                    title: "Media sent",
-                    description: "Your media has been sent successfully",
-                })
+                if (addMessage) addMessage(result.data as any)
+                toast({ title: "Media sent", description: "Your media has been sent successfully" })
                 setShowMediaModal(false)
             } else {
-                toast({
-                    title: "Upload failed",
-                    description: result.message || "Failed to upload media",
-                    variant: "destructive"
-                })
+                toast({ title: "Upload failed", description: result.message || "Failed to upload media", variant: "destructive" })
             }
-        } catch (error) {
-            console.error('Error uploading media:', error)
-            toast({
-                title: "Upload failed",
-                description: "An error occurred while uploading",
-                variant: "destructive"
-            })
+        } catch {
+            toast({ title: "Upload failed", description: "An error occurred while uploading", variant: "destructive" })
         } finally {
-            setUploading(false)
-            setUploadProgress(0)
+            setUploading(false); setUploadProgress(0)
         }
     }
 
+    const canSend = !!messageText.trim() && isConnected
+
     return (
         <>
-            <div className="bg-white dark:bg-darkBg-card p-3 sm:p-4 border-t border-gray-100 dark:border-darkBorder-light shadow-sm fixed bottom-0 md:bottom-0 left-0 right-0 md:relative">
-                <div className="flex items-center gap-1 sm:gap-2">
-                    <div className="relative" ref={dropdownRef}>
+            {/* Outer wrapper is `relative` so the emoji picker can be positioned against it */}
+            <div
+                ref={wrapperRef}
+                className="relative bg-white dark:bg-darkBg-card px-3 py-2 sm:px-4 sm:py-3 border-t border-gray-100 dark:border-darkBorder-light"
+            >
+                {/* ── Emoji picker popover ────────────────────────────────────────────── */}
+                {showEmojiPicker && (
+                    <div
+                        ref={emojiPickerRef}
+                        // Mobile: full-width flush with the input bar
+                        // Desktop (sm+): 300 px, right-aligned
+                        className="absolute bottom-full left-0 right-0 sm:left-auto sm:right-0 sm:w-[300px] mb-1 z-50 animate-fadeIn"
+                        style={{
+                            filter: "drop-shadow(0 -4px 24px rgba(0,0,0,0.18))",
+                            // Round only the top corners on mobile (picker is flush at bottom)
+                        }}
+                    >
+                        {/* Inner wrapper clips the picker and applies border + radius */}
+                        <div
+                            className={`
+                                overflow-hidden rounded-t-2xl sm:rounded-2xl
+                                border border-b-0 sm:border-b
+                                ${isDark
+                                    ? "border-[rgba(255,255,255,0.07)]"
+                                    : "border-gray-200"
+                                }
+                            `}
+                            style={pickerVars(isDark)}
+                        >
+                            <EmojiPicker
+                                onEmojiClick={handleEmojiClick}
+                                theme={isDark ? "dark" as any : "light" as any}
+                                searchPlaceholder="Search emoji…"
+                                skinTonesDisabled
+                                // Full-width on mobile, fixed on desktop
+                                width="100%"
+                                height={340}
+                                previewConfig={{ showPreview: false }}
+                                lazyLoadEmojis
+                            />
+                        </div>
+                    </div>
+                )}
+
+                {/* ── Input row ──────────────────────────────────────────────────────── */}
+                <div className="flex items-end gap-1 sm:gap-2">
+
+                    {/* Attachment */}
+                    <div className="relative flex-shrink-0 pb-0.5" ref={dropdownRef}>
                         <Button
-                            variant="ghost"
-                            size="icon"
+                            variant="ghost" size="icon"
                             onClick={() => setShowOptions(!showOptions)}
-                            className={`transition-all duration-300 h-8 w-8 sm:h-10 sm:w-10 hover:bg-gray-100 dark:hover:bg-darkBg-interactive ${showOptions ? "bg-gray-100 dark:bg-darkBg-interactive" : ""}`}
+                            className={`h-8 w-8 sm:h-9 sm:w-9 transition-colors hover:bg-gray-100 dark:hover:bg-darkBg-interactive ${showOptions ? "bg-gray-100 dark:bg-darkBg-interactive" : ""}`}
                             aria-label="Attachments"
                         >
-                            <Paperclip size={16} className="sm:size-20 text-gray-500 dark:text-gray-400" />
+                            <Paperclip size={16} className="text-gray-500 dark:text-gray-400" />
                         </Button>
-
                         <OptionsDropdown isOpen={showOptions} onOptionSelect={handleOptionSelect} />
                     </div>
 
+                    {/* Media */}
                     <Button
-                        variant="ghost"
-                        size="icon"
+                        variant="ghost" size="icon"
                         onClick={() => setShowMediaModal(true)}
-                        className="hover:bg-gray-100 dark:hover:bg-darkBg-interactive transition-colors h-8 w-8 sm:h-10 sm:w-10"
+                        className="flex-shrink-0 h-8 w-8 sm:h-9 sm:w-9 mb-0.5 hover:bg-gray-100 dark:hover:bg-darkBg-interactive transition-colors"
                         aria-label="Add media"
                     >
-                        <ImageIcon size={16} className="sm:size-20 text-gray-500 dark:text-gray-400" />
+                        <ImageIcon size={16} className="text-gray-500 dark:text-gray-400" />
                     </Button>
 
+                    {/* Textarea */}
                     <div className="relative flex-1">
-                        <Input
-                            placeholder="Type a message..."
+                        <textarea
+                            ref={textareaRef}
+                            placeholder={!isConnected ? "Connecting…" : "Type a message…"}
                             value={messageText}
-                            onChange={(e) => {
-                                const value = e.target.value
-                                setMessageText(value)
-
-                                if (activeChat && startTyping && stopTyping) {
-                                    if (value.trim()) {
-                                        startTyping(activeChat)
-                                    } else {
-                                        stopTyping(activeChat)
-                                    }
-                                }
-                            }}
-                            onKeyDown={(e) => e.key === "Enter" && handleSendMessage()}
-                            onBlur={() => {
-                                // Stop typing when input loses focus
-                                if (activeChat && stopTyping) {
-                                    stopTyping(activeChat)
-                                }
-                            }}
-                            className="rounded-full bg-gray-50 dark:bg-darkBg-interactive border border-gray-200 dark:border-darkBorder-light py-1.5 sm:py-2 px-3 sm:px-4 focus-visible:ring-2 focus-visible:ring-brand-green dark:focus-visible:ring-brand-gold focus-visible:ring-opacity-50 transition-all pr-8 sm:pr-10 text-sm text-gray-900 dark:text-white"
+                            onChange={handleChange}
+                            onKeyDown={handleKeyDown}
+                            onBlur={handleBlur}
+                            onClick={saveCursor}
+                            onKeyUp={saveCursor}
                             disabled={!isConnected}
+                            rows={1}
+                            aria-label="Message input"
+                            aria-multiline="true"
+                            className="w-full resize-none rounded-2xl bg-gray-50 dark:bg-darkBg-interactive border border-gray-200 dark:border-darkBorder-light py-2.5 pl-4 pr-10 text-base leading-6 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-brand-green dark:focus:ring-brand-gold focus:ring-opacity-50 disabled:opacity-50 disabled:cursor-not-allowed overflow-hidden"
+                            style={{ minHeight: "44px" }}
                         />
-
-                        <Button
-                            variant="ghost"
-                            size="icon"
-                            className="absolute right-1 top-1/2 transform -translate-y-1/2 hover:bg-transparent border-0 h-6 w-6 sm:h-8 sm:w-8"
-                            aria-label="Emoji"
+                        {/* Emoji trigger — anchored to bottom-right of the textarea */}
+                        <button
+                            ref={emojiButtonRef}
+                            type="button"
+                            onClick={() => setShowEmojiPicker((v) => !v)}
+                            aria-label="Open emoji picker"
+                            aria-expanded={showEmojiPicker}
+                            className={`absolute right-2 bottom-2 h-7 w-7 flex items-center justify-center rounded-full transition-colors ${
+                                showEmojiPicker
+                                    ? "text-brand-green dark:text-brand-gold"
+                                    : "text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
+                            }`}
                         >
-                            <Smile size={16} className="sm:size-18 text-gray-500" />
-                        </Button>
+                            <Smile size={15} />
+                        </button>
                     </div>
 
+                    {/* Send */}
                     <Button
                         onClick={handleSendMessage}
                         size="icon"
-                        disabled={!messageText.trim() || !isConnected}
-                        className="bg-brand-green dark:bg-brand-gold hover:bg-brand-green/90 dark:hover:bg-brand-gold/90 text-white dark:text-darkBg-main shadow-md transition-all hover:shadow-lg rounded-full h-8 w-8 sm:h-10 sm:w-10 disabled:opacity-50 disabled:cursor-not-allowed"
+                        disabled={!canSend}
                         aria-label="Send message"
+                        className={`flex-shrink-0 mb-0.5 h-8 w-8 sm:h-9 sm:w-9 rounded-full transition-all duration-200 shadow-sm ${
+                            canSend
+                                ? "bg-brand-green dark:bg-brand-gold hover:bg-brand-green/90 dark:hover:bg-brand-gold/90 text-white dark:text-darkBg-main hover:shadow-md"
+                                : "bg-gray-200 dark:bg-darkBg-interactive text-gray-400 cursor-not-allowed"
+                        }`}
                     >
-                        <Send size={16} className="sm:size-18" />
+                        <Send size={15} />
                     </Button>
                 </div>
+
+                {/* Hint shown while typing */}
+                {messageText.length > 0 && (
+                    <p className="text-[10px] text-gray-400 dark:text-gray-500 mt-1 pl-1 select-none">
+                        Shift+Enter for new line
+                    </p>
+                )}
             </div>
 
-            {/* Media Upload Modal */}
             <MediaUploadModal
                 isOpen={showMediaModal}
                 onClose={() => setShowMediaModal(false)}

--- a/components/settings/NotificationsTab.tsx
+++ b/components/settings/NotificationsTab.tsx
@@ -1,11 +1,14 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Separator } from "@/components/ui/separator";
 import { Label } from "@/components/ui/label";
 import { toast } from "@/hooks/use-toast";
+import { Volume2, VolumeX, Smartphone, BellRing } from "lucide-react";
 import { NotificationSettings } from "@/types/settings.types";
+import { savePrefs, getPrefs } from "@/services/soundService";
+import { notificationService } from "@/services/notificationService";
 
 export const NotificationsTab: React.FC = () => {
   const [notificationSettings, setNotificationSettings] = useState<NotificationSettings>({
@@ -13,34 +16,70 @@ export const NotificationsTab: React.FC = () => {
     notifySent: true,
     notifyReceived: true,
     notifyRequested: true,
-    
+
     // Group Notifications
     notifyGroupActivity: true,
     notifyContribution: true,
-    
+
     // Notification Channels
     channelPush: true,
     channelEmail: true,
     channelSms: false,
+
+    // Sound & Vibration — loaded from localStorage
+    soundEnabled: true,
+    vibrationEnabled: true,
   });
 
   const [saving, setSaving] = useState(false);
 
+  // Hydrate sound/vibration from localStorage on mount
+  useEffect(() => {
+    const prefs = getPrefs();
+    setNotificationSettings((prev) => ({
+      ...prev,
+      soundEnabled: prefs.soundEnabled,
+      vibrationEnabled: prefs.vibrationEnabled,
+    }));
+  }, []);
+
   const updateSetting = (key: keyof NotificationSettings, value: boolean) => {
-    setNotificationSettings(prev => ({ ...prev, [key]: value }));
+    setNotificationSettings((prev) => ({ ...prev, [key]: value }));
+
+    // Sound & vibration take effect instantly — no Save button needed
+    if (key === "soundEnabled") {
+      savePrefs({ soundEnabled: value });
+      notificationService.syncFromPrefs();
+      // Play a preview when enabling so the user hears what to expect
+      if (value) {
+        import("@/services/soundService").then(({ soundService }) => {
+          soundService.playMessageSound();
+        });
+      }
+    }
+    if (key === "vibrationEnabled") {
+      savePrefs({ vibrationEnabled: value });
+      notificationService.syncFromPrefs();
+      // Short vibration preview when enabling
+      if (value) {
+        import("@/services/soundService").then(({ soundService }) => {
+          soundService.vibrate([60]);
+        });
+      }
+    }
   };
 
   const handleSavePreferences = async () => {
     setSaving(true);
     try {
       // TODO: Implement API call to save notification preferences
-      await new Promise(resolve => setTimeout(resolve, 1000)); // Simulate API call
-      
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
       toast({
         title: "Preferences saved",
         description: "Your notification preferences have been updated successfully.",
       });
-    } catch (error) {
+    } catch {
       toast({
         title: "Error",
         description: "Failed to save notification preferences. Please try again.",
@@ -55,133 +94,246 @@ export const NotificationsTab: React.FC = () => {
     <Card className="dark:bg-darkBg-card dark:border-darkBorder-light">
       <CardHeader>
         <CardTitle className="dark:text-white">Notification Preferences</CardTitle>
-        <CardDescription className="dark:text-gray-400">Choose how you want to be notified</CardDescription>
+        <CardDescription className="dark:text-gray-400">
+          Choose how you want to be notified
+        </CardDescription>
       </CardHeader>
+
       <CardContent className="space-y-6">
+
+        {/* ── Transaction Notifications ─────────────────────────────────────── */}
         <div>
-          <h3 className="text-base sm:text-lg font-medium mb-3 dark:text-white">Transaction Notifications</h3>
+          <h3 className="text-base sm:text-lg font-medium mb-3 dark:text-white">
+            Transaction Notifications
+          </h3>
           <div className="space-y-3">
             <div className="flex items-center justify-between gap-3">
               <div className="space-y-0.5 flex-1 min-w-0">
                 <Label htmlFor="notify-sent" className="dark:text-gray-300">Money Sent</Label>
-                <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">Get notified when you send money</p>
+                <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">
+                  Get notified when you send money
+                </p>
               </div>
-              <Switch 
-                id="notify-sent" 
+              <Switch
+                id="notify-sent"
                 checked={notificationSettings.notifySent}
-                onCheckedChange={(checked) => updateSetting('notifySent', checked)}
+                onCheckedChange={(v) => updateSetting("notifySent", v)}
               />
             </div>
             <Separator className="dark:bg-darkBorder-light" />
             <div className="flex items-center justify-between gap-3">
               <div className="space-y-0.5 flex-1 min-w-0">
                 <Label htmlFor="notify-received" className="dark:text-gray-300">Money Received</Label>
-                <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">Get notified when you receive money</p>
+                <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">
+                  Get notified when you receive money
+                </p>
               </div>
-              <Switch 
-                id="notify-received" 
+              <Switch
+                id="notify-received"
                 checked={notificationSettings.notifyReceived}
-                onCheckedChange={(checked) => updateSetting('notifyReceived', checked)}
+                onCheckedChange={(v) => updateSetting("notifyReceived", v)}
               />
             </div>
             <Separator className="dark:bg-darkBorder-light" />
             <div className="flex items-center justify-between gap-3">
               <div className="space-y-0.5 flex-1 min-w-0">
                 <Label htmlFor="notify-requested" className="dark:text-gray-300">Money Requested</Label>
-                <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">Get notified when someone requests money from you</p>
+                <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">
+                  Get notified when someone requests money from you
+                </p>
               </div>
-              <Switch 
-                id="notify-requested" 
+              <Switch
+                id="notify-requested"
                 checked={notificationSettings.notifyRequested}
-                onCheckedChange={(checked) => updateSetting('notifyRequested', checked)}
+                onCheckedChange={(v) => updateSetting("notifyRequested", v)}
               />
             </div>
           </div>
         </div>
 
+        {/* ── Group Notifications ───────────────────────────────────────────── */}
         <div>
-          <h3 className="text-base sm:text-lg font-medium mb-3 dark:text-white">Group Notifications</h3>
+          <h3 className="text-base sm:text-lg font-medium mb-3 dark:text-white">
+            Group Notifications
+          </h3>
           <div className="space-y-3">
             <div className="flex items-center justify-between gap-3">
               <div className="space-y-0.5 flex-1 min-w-0">
                 <Label htmlFor="notify-group-activity" className="dark:text-gray-300">Group Activity</Label>
-                <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">Get notified about new messages in groups</p>
+                <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">
+                  Get notified about new messages in groups
+                </p>
               </div>
-              <Switch 
-                id="notify-group-activity" 
+              <Switch
+                id="notify-group-activity"
                 checked={notificationSettings.notifyGroupActivity}
-                onCheckedChange={(checked) => updateSetting('notifyGroupActivity', checked)}
+                onCheckedChange={(v) => updateSetting("notifyGroupActivity", v)}
               />
             </div>
             <Separator className="dark:bg-darkBorder-light" />
             <div className="flex items-center justify-between gap-3">
               <div className="space-y-0.5 flex-1 min-w-0">
                 <Label htmlFor="notify-contribution" className="dark:text-gray-300">Contribution Updates</Label>
-                <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">Get notified about contribution group updates</p>
+                <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">
+                  Get notified about contribution group updates
+                </p>
               </div>
-              <Switch 
-                id="notify-contribution" 
+              <Switch
+                id="notify-contribution"
                 checked={notificationSettings.notifyContribution}
-                onCheckedChange={(checked) => updateSetting('notifyContribution', checked)}
+                onCheckedChange={(v) => updateSetting("notifyContribution", v)}
               />
             </div>
           </div>
         </div>
 
+        {/* ── Notification Channels ─────────────────────────────────────────── */}
         <div>
-          <h3 className="text-base sm:text-lg font-medium mb-3 dark:text-white">Notification Channels</h3>
+          <h3 className="text-base sm:text-lg font-medium mb-3 dark:text-white">
+            Notification Channels
+          </h3>
           <div className="space-y-3">
             <div className="flex items-center justify-between gap-3">
               <div className="space-y-0.5 flex-1 min-w-0">
                 <Label htmlFor="channel-push" className="dark:text-gray-300">Push Notifications</Label>
-                <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">Receive notifications on your device</p>
+                <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">
+                  Receive notifications on your device
+                </p>
               </div>
-              <Switch 
-                id="channel-push" 
+              <Switch
+                id="channel-push"
                 checked={notificationSettings.channelPush}
-                onCheckedChange={(checked) => updateSetting('channelPush', checked)}
+                onCheckedChange={(v) => updateSetting("channelPush", v)}
               />
             </div>
             <Separator className="dark:bg-darkBorder-light" />
             <div className="flex items-center justify-between gap-3">
               <div className="space-y-0.5 flex-1 min-w-0">
                 <Label htmlFor="channel-email" className="dark:text-gray-300">Email Notifications</Label>
-                <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">Receive notifications via email</p>
+                <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">
+                  Receive notifications via email
+                </p>
               </div>
-              <Switch 
-                id="channel-email" 
+              <Switch
+                id="channel-email"
                 checked={notificationSettings.channelEmail}
-                onCheckedChange={(checked) => updateSetting('channelEmail', checked)}
+                onCheckedChange={(v) => updateSetting("channelEmail", v)}
               />
             </div>
-            <Separator />
-            <div className="flex items-center justify-between">
-              <div className="space-y-0.5">
-                <Label htmlFor="channel-sms">SMS Notifications</Label>
-                <p className="text-sm text-gray-500">Receive notifications via SMS</p>
+            <Separator className="dark:bg-darkBorder-light" />
+            <div className="flex items-center justify-between gap-3">
+              <div className="space-y-0.5 flex-1 min-w-0">
+                <Label htmlFor="channel-sms" className="dark:text-gray-300">SMS Notifications</Label>
+                <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">
+                  Receive notifications via SMS
+                </p>
               </div>
-              <Switch 
-                id="channel-sms" 
+              <Switch
+                id="channel-sms"
                 checked={notificationSettings.channelSms}
-                onCheckedChange={(checked) => updateSetting('channelSms', checked)}
+                onCheckedChange={(v) => updateSetting("channelSms", v)}
               />
             </div>
           </div>
         </div>
+
+        {/* ── Sound & Vibration ─────────────────────────────────────────────── */}
+        <div>
+          <div className="flex items-center gap-2 mb-3">
+            <BellRing size={18} className="text-brand-green dark:text-brand-gold flex-shrink-0" />
+            <h3 className="text-base sm:text-lg font-medium dark:text-white">Sound & Vibration</h3>
+          </div>
+          <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400 mb-4">
+            These settings take effect immediately and apply to all incoming message notifications.
+          </p>
+
+          <div className="space-y-3">
+            {/* Sound toggle */}
+            <div className="flex items-center justify-between gap-3 rounded-xl p-3 bg-gray-50 dark:bg-darkBg-interactive border border-gray-100 dark:border-darkBorder-light">
+              <div className="flex items-center gap-3 flex-1 min-w-0">
+                <div className={`w-9 h-9 rounded-full flex items-center justify-center flex-shrink-0 transition-colors ${
+                  notificationSettings.soundEnabled
+                    ? "bg-brand-green/10 dark:bg-brand-gold/10"
+                    : "bg-gray-200 dark:bg-darkBg-card"
+                }`}>
+                  {notificationSettings.soundEnabled
+                    ? <Volume2 size={18} className="text-brand-green dark:text-brand-gold" />
+                    : <VolumeX size={18} className="text-gray-400 dark:text-gray-500" />
+                  }
+                </div>
+                <div className="space-y-0.5 min-w-0">
+                  <Label htmlFor="sound-enabled" className="dark:text-gray-300 cursor-pointer">
+                    Notification Sound
+                  </Label>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    {notificationSettings.soundEnabled ? "A gentle tone plays on new messages" : "Silent — no sound on new messages"}
+                  </p>
+                </div>
+              </div>
+              <Switch
+                id="sound-enabled"
+                checked={notificationSettings.soundEnabled}
+                onCheckedChange={(v) => updateSetting("soundEnabled", v)}
+              />
+            </div>
+
+            <Separator className="dark:bg-darkBorder-light" />
+
+            {/* Vibration toggle */}
+            <div className="flex items-center justify-between gap-3 rounded-xl p-3 bg-gray-50 dark:bg-darkBg-interactive border border-gray-100 dark:border-darkBorder-light">
+              <div className="flex items-center gap-3 flex-1 min-w-0">
+                <div className={`w-9 h-9 rounded-full flex items-center justify-center flex-shrink-0 transition-colors ${
+                  notificationSettings.vibrationEnabled
+                    ? "bg-brand-green/10 dark:bg-brand-gold/10"
+                    : "bg-gray-200 dark:bg-darkBg-card"
+                }`}>
+                  <Smartphone
+                    size={18}
+                    className={notificationSettings.vibrationEnabled
+                      ? "text-brand-green dark:text-brand-gold"
+                      : "text-gray-400 dark:text-gray-500"
+                    }
+                  />
+                </div>
+                <div className="space-y-0.5 min-w-0">
+                  <Label htmlFor="vibration-enabled" className="dark:text-gray-300 cursor-pointer">
+                    Vibration
+                  </Label>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    {notificationSettings.vibrationEnabled
+                      ? "Device vibrates on new messages"
+                      : "No vibration on new messages"}
+                  </p>
+                </div>
+              </div>
+              <Switch
+                id="vibration-enabled"
+                checked={notificationSettings.vibrationEnabled}
+                onCheckedChange={(v) => updateSetting("vibrationEnabled", v)}
+              />
+            </div>
+
+            <p className="text-[11px] text-gray-400 dark:text-gray-500 px-1">
+              Vibration is only available on supported mobile devices. Sound requires interaction with the page before it plays.
+            </p>
+          </div>
+        </div>
+
       </CardContent>
+
       <CardFooter>
-        <Button 
+        <Button
           className="bg-[#00B512] hover:bg-[#009E10] dark:bg-brand-gold dark:hover:bg-brand-goldHover text-white dark:text-[#00313A]"
           onClick={handleSavePreferences}
           disabled={saving}
         >
           {saving ? (
             <div className="flex items-center gap-2">
-              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white" />
               <span>Saving...</span>
             </div>
           ) : (
-            'Save preferences'
+            "Save preferences"
           )}
         </Button>
       </CardFooter>

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.18",
+        "emoji-picker-react": "^4.18.0",
         "jose": "^6.0.12",
         "jspdf": "^3.0.4",
         "lucide-react": "^0.469.0",
@@ -6413,6 +6414,21 @@
       "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "license": "ISC"
     },
+    "node_modules/emoji-picker-react": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-4.18.0.tgz",
+      "integrity": "sha512-vLTrLfApXAIciguGE57pXPWs9lPLBspbEpPMiUq03TIli2dHZBiB+aZ0R9/Wat0xmTfcd4AuEzQgSYxEZ8C88Q==",
+      "license": "MIT",
+      "dependencies": {
+        "flairup": "1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "license": "MIT"
@@ -7359,6 +7375,12 @@
       "engines": {
         "node": ">= 10.13.0"
       }
+    },
+    "node_modules/flairup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/flairup/-/flairup-1.0.0.tgz",
+      "integrity": "sha512-IKlE+pNvL2R+kVL1kEhUYqRxVqeFnjiIvHWDMLFXNaqyUdFXQM2wte44EfMYJNHkW16X991t2Zg8apKkhv7OBA==",
+      "license": "MIT"
     },
     "node_modules/flat-cache": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.18",
+    "emoji-picker-react": "^4.18.0",
     "jose": "^6.0.12",
     "jspdf": "^3.0.4",
     "lucide-react": "^0.469.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       dayjs:
         specifier: ^1.11.18
         version: 1.11.19
+      emoji-picker-react:
+        specifier: ^4.18.0
+        version: 4.18.0(react@18.3.1)
       jose:
         specifier: ^6.0.12
         version: 6.1.3
@@ -2647,6 +2650,12 @@ packages:
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
 
+  emoji-picker-react@4.18.0:
+    resolution: {integrity: sha512-vLTrLfApXAIciguGE57pXPWs9lPLBspbEpPMiUq03TIli2dHZBiB+aZ0R9/Wat0xmTfcd4AuEzQgSYxEZ8C88Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16'
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -2928,6 +2937,9 @@ packages:
   findup-sync@5.0.0:
     resolution: {integrity: sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==}
     engines: {node: '>= 10.13.0'}
+
+  flairup@1.0.0:
+    resolution: {integrity: sha512-IKlE+pNvL2R+kVL1kEhUYqRxVqeFnjiIvHWDMLFXNaqyUdFXQM2wte44EfMYJNHkW16X991t2Zg8apKkhv7OBA==}
 
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
@@ -7795,6 +7807,11 @@ snapshots:
 
   electron-to-chromium@1.5.267: {}
 
+  emoji-picker-react@4.18.0(react@18.3.1):
+    dependencies:
+      flairup: 1.0.0
+      react: 18.3.1
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -8235,6 +8252,8 @@ snapshots:
       is-glob: 4.0.3
       micromatch: 4.0.8
       resolve-dir: 1.0.1
+
+  flairup@1.0.0: {}
 
   flat-cache@3.2.0:
     dependencies:

--- a/services/notificationService.ts
+++ b/services/notificationService.ts
@@ -1,11 +1,13 @@
 import { NotificationType, NotificationPayload, NotificationConfig } from '@/types/notification.types';
 import { toast } from '@/hooks/use-toast';
+import { soundService, getPrefs } from './soundService';
 
 class NotificationService {
   private config: NotificationConfig = {
     enablePush: true,
     enableToast: true,
-    enableSound: false,
+    enableSound: true,
+    enableVibration: true,
   };
 
   private userId: string | null = null;
@@ -23,13 +25,25 @@ class NotificationService {
     this.config = { ...this.config, ...config };
   }
 
+  /**
+   * Sync runtime config from localStorage prefs.
+   * Called once on app boot and after the user changes settings.
+   */
+  syncFromPrefs() {
+    const prefs = getPrefs();
+    this.updateConfig({
+      enableSound: prefs.soundEnabled,
+      enableVibration: prefs.vibrationEnabled,
+    });
+  }
+
   private shouldNotify(payload: NotificationPayload): boolean {
     // Don't notify if it's from the current user
     if (payload.senderId === this.userId) return false;
-    
+
     // Don't notify if it's from the active chat (user is already viewing it)
     if (payload.chatId && payload.chatId === this.activeChat) return false;
-    
+
     return true;
   }
 
@@ -61,8 +75,17 @@ class NotificationService {
     });
   }
 
+  /** Play sound + vibration according to current config. */
+  private playFeedback() {
+    if (this.config.enableSound) soundService.playMessageSound();
+    if (this.config.enableVibration) soundService.vibrate();
+  }
+
   async notify(payload: NotificationPayload) {
     if (!this.shouldNotify(payload)) return;
+
+    // Auditory / haptic feedback first (feels most immediate)
+    this.playFeedback();
 
     // Send push notification
     await this.sendPushNotification(payload);
@@ -124,14 +147,14 @@ class NotificationService {
     from: string;
     action: 'received' | 'accepted';
   }) {
-    const title = data.action === 'received' 
+    const title = data.action === 'received'
       ? `New contact request from ${data.from}`
       : `${data.from} accepted your contact request`;
-    
+
     await this.notify({
       type: NotificationType.CONTACT_REQUEST,
       title,
-      message: data.action === 'received' 
+      message: data.action === 'received'
         ? 'Tap to view and respond'
         : 'You can now start chatting',
       url: `${window.location.origin}/contacts`,

--- a/services/soundService.ts
+++ b/services/soundService.ts
@@ -1,0 +1,142 @@
+const STORAGE_KEY = "que_notif_prefs"
+
+export interface NotifPrefs {
+  soundEnabled: boolean
+  vibrationEnabled: boolean
+}
+
+function loadPrefs(): NotifPrefs {
+  if (typeof window === "undefined") return { soundEnabled: true, vibrationEnabled: true }
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw) return { soundEnabled: true, vibrationEnabled: true, ...JSON.parse(raw) }
+  } catch {
+    // ignore parse errors
+  }
+  return { soundEnabled: true, vibrationEnabled: true }
+}
+
+export function savePrefs(prefs: Partial<NotifPrefs>) {
+  if (typeof window === "undefined") return
+  try {
+    const current = loadPrefs()
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...current, ...prefs }))
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function getPrefs(): NotifPrefs {
+  return loadPrefs()
+}
+
+let _ctx: AudioContext | null = null
+
+function getCtx(): AudioContext | null {
+  if (typeof window === "undefined") return null
+  try {
+    if (!_ctx || _ctx.state === "closed") {
+      const Ctor =
+        window.AudioContext ??
+        (window as unknown as Record<string, unknown>)["webkitAudioContext"] as typeof AudioContext | undefined
+      if (!Ctor) return null
+      _ctx = new Ctor()
+    }
+    return _ctx
+  } catch {
+    return null
+  }
+}
+
+function registerUnlockListeners() {
+  if (typeof window === "undefined") return
+
+  const unlock = () => {
+    const ctx = getCtx()
+    if (ctx && ctx.state === "suspended") {
+      ctx.resume().catch(() => { })
+    }
+  }
+
+  window.addEventListener("click", unlock, { once: true, capture: true })
+  window.addEventListener("touchstart", unlock, { once: true, capture: true })
+  window.addEventListener("keydown", unlock, { once: true, capture: true })
+  window.addEventListener("pointerdown", unlock, { once: true, capture: true })
+}
+
+registerUnlockListeners()
+
+
+class SoundService {
+  playMessageSound() {
+    if (!getPrefs().soundEnabled) return
+    try {
+      const ctx = getCtx()
+      if (!ctx) return
+
+      if (ctx.state === "suspended") {
+        ctx.resume().then(() => this._ding(ctx)).catch(() => { })
+        return
+      }
+
+      this._ding(ctx)
+    } catch {
+      // Silently fail — notification sound is non-critical
+    }
+  }
+
+  private _ding(ctx: AudioContext) {
+    try {
+      const t = ctx.currentTime
+
+      const masterGain = ctx.createGain()
+      masterGain.gain.setValueAtTime(0.85, t)
+      masterGain.connect(ctx.destination)
+
+      const playNote = (freq: number, startAt: number, duration: number) => {
+        const osc1 = ctx.createOscillator()
+        const gain1 = ctx.createGain()
+        osc1.type = "triangle"
+        osc1.frequency.setValueAtTime(freq, startAt)
+        gain1.gain.setValueAtTime(0, startAt)
+        gain1.gain.linearRampToValueAtTime(0.7, startAt + 0.006) // sharp punch
+        gain1.gain.exponentialRampToValueAtTime(0.001, startAt + duration)
+        osc1.connect(gain1)
+        gain1.connect(masterGain)
+        osc1.start(startAt)
+        osc1.stop(startAt + duration + 0.01)
+
+        const osc2 = ctx.createOscillator()
+        const gain2 = ctx.createGain()
+        osc2.type = "sine"
+        osc2.frequency.setValueAtTime(freq * 2, startAt)
+        gain2.gain.setValueAtTime(0, startAt)
+        gain2.gain.linearRampToValueAtTime(0.25, startAt + 0.006)
+        gain2.gain.exponentialRampToValueAtTime(0.001, startAt + duration * 0.7)
+        osc2.connect(gain2)
+        gain2.connect(masterGain)
+        osc2.start(startAt)
+        osc2.stop(startAt + duration + 0.01)
+      }
+
+      playNote(1046, t, 0.18)
+      playNote(1318, t + 0.12, 0.22)
+    } catch {
+      // Ignore — can fail if context was closed mid-play
+    }
+  }
+
+  vibrate(pattern: number | number[] = [70, 40, 70]) {
+    if (!getPrefs().vibrationEnabled) return
+    try {
+      if (typeof window !== "undefined" && "vibrate" in navigator) {
+        navigator.vibrate(pattern)
+      }
+    } catch {
+      // Silently fail on unsupported devices
+    }
+  }
+}
+
+export const soundService = new SoundService()
+export default soundService

--- a/types/notification.types.ts
+++ b/types/notification.types.ts
@@ -131,6 +131,7 @@ export interface NotificationConfig {
   enablePush: boolean;
   enableToast: boolean;
   enableSound: boolean;
+  enableVibration: boolean;
 }
 
 // Existing notification types (for UI dropdown and API)

--- a/types/settings.types.ts
+++ b/types/settings.types.ts
@@ -92,15 +92,19 @@ export interface NotificationSettings {
   notifySent: boolean;
   notifyReceived: boolean;
   notifyRequested: boolean;
-  
+
   // Group Notifications
   notifyGroupActivity: boolean;
   notifyContribution: boolean;
-  
+
   // Notification Channels
   channelPush: boolean;
   channelEmail: boolean;
   channelSms: boolean;
+
+  // Sound & Vibration
+  soundEnabled: boolean;
+  vibrationEnabled: boolean;
 }
 
 export interface PaymentMethod {


### PR DESCRIPTION
## Summary

A focused UX pass on the chat experience and notification system.

### Chat input
- Replaced single-line `<Input>` with an auto-resizing `<textarea>` (max 160 px, then scrolls internally)
- `Enter` sends, `Shift+Enter` inserts a newline
- Font size raised to `16px` (prevents iOS Safari auto-zoom on focus)
- Buttons align to the bottom edge as the textarea grows

### Emoji picker
- Lazy-loaded via `next/dynamic` — zero bundle cost until first open
- Full CSS variable theming to match app design tokens (light + dark)
- Mobile: full-width flush panel · Desktop: 300 px right-aligned popover
- Inserts emoji at the cursor position, not just appended to the end

### Keyboard / layout fix
- Chat container switched from `h-screen` → `h-[100dvh]` so the layout shrinks when the mobile soft keyboard opens
- `MessageInput` removed from `fixed bottom-0` — now a natural `flex-shrink-0` element, always visible above the keyboard

### Date separators
- Messages grouped by calendar day with "Today" / "Yesterday" / "Friday, 20 March 2026" indicators
- Pill-shaped label with hairline rules, supports light and dark themes

### Sound & vibration notifications
- `soundService.ts`: two-note C6 → E6 double-pop synthesised via Web Audio API (no audio file needed). Triangle + sine harmonic stack at high gain for clear audibility
- AudioContext auto-unlocked on first user gesture so WebSocket-triggered sounds are never blocked by the browser autoplay policy
- Vibration API wrapper with double-pulse haptic pattern
- `NotificationsTab` — new Sound & Vibration section: toggles write to `localStorage` instantly and sync the notification service live. Enabling either plays an immediate preview

## Test plan
- [x] Open a chat on mobile — bottom nav disappears, soft keyboard does not overlap the input
- [x] Type a multi-line message — textarea expands smoothly, stops at ~5 lines then scrolls
- [x] Press Enter — message sends; Shift+Enter — new line inserted
- [x] Open emoji picker — appears above input, closes on outside click / Escape, selected emoji lands at cursor
- [x] Load a chat with messages from multiple days — date separators appear correctly for Today, Yesterday, and older dates
- [x] Receive a message while on another tab — notification sound plays (two-note pop) and device vibrates
- [x] Settings → Notifications → toggle Sound off → receive a message → no sound
- [x] Settings → Notifications → toggle Vibration off → receive a message → no vibration
- [x] Toggle Sound ON from settings — preview tone plays immediately