### PR TITLE
feat(chat): add secure dm frontend foundation

### DIFF
--- a/app/contacts/components/ContactsTable.tsx
+++ b/app/contacts/components/ContactsTable.tsx
@@ -17,6 +17,7 @@ import { useAuthToken } from "@/hooks/use-auth-token";
 import { useToast } from "@/hooks/use-toast";
 import { ManageTagsDialog } from "./ManageTagsDialog";
 import { useRouter } from "next/navigation";
+import { createOrGetPreferredDmChat } from "@/services/secureChatService";
 
 interface ContactsTableProps {
     contacts: Contact[];
@@ -52,6 +53,40 @@ export function ContactsTable({ contacts, isLoading, onSelect }: ContactsTablePr
             toast({
                 title: "Error",
                 description: "Failed to update favorite status",
+                variant: "destructive",
+            });
+        }
+    };
+
+    const handleSendMessage = async (contact: Contact) => {
+        if (!token) {
+            toast({
+                title: "Authentication required",
+                description: "Please log in again to open a conversation.",
+                variant: "destructive",
+            });
+            return;
+        }
+
+        try {
+            const result = await createOrGetPreferredDmChat({
+                token,
+                participantId: contact.otherUser.id,
+            });
+
+            sessionStorage.setItem("pendingChatId", result.chatId);
+            router.push("/chat");
+
+            toast({
+                title: result.usedSecure ? "Secure Chat Ready" : "Chat Ready",
+                description: result.usedSecure
+                    ? `Opening a secure conversation with ${contact.otherUser.firstName} ${contact.otherUser.lastName}.`
+                    : `Opening your conversation with ${contact.otherUser.firstName} ${contact.otherUser.lastName}.`,
+            });
+        } catch (error: any) {
+            toast({
+                title: "Unable to open chat",
+                description: error?.data?.message || error?.message || "Please try again.",
                 variant: "destructive",
             });
         }
@@ -159,7 +194,9 @@ export function ContactsTable({ contacts, isLoading, onSelect }: ContactsTablePr
                                                 <DropdownMenuItem onClick={(e) => handleOpenProfile(e, contact.otherUser.id)}>
                                                     View Profile
                                                 </DropdownMenuItem>
-                                                <DropdownMenuItem>Send Message</DropdownMenuItem>
+                                                <DropdownMenuItem onClick={() => void handleSendMessage(contact)}>
+                                                    Send Message
+                                                </DropdownMenuItem>
                                                 <DropdownMenuItem>Send Money</DropdownMenuItem>
                                                 <DropdownMenuItem onSelect={() => setManagingTagsContactId(contact.id)}>
                                                     Edit Tags
@@ -216,7 +253,9 @@ export function ContactsTable({ contacts, isLoading, onSelect }: ContactsTablePr
                                         <DropdownMenuItem onClick={(e) => handleOpenProfile(e, contact.otherUser.id)}>
                                             View Profile
                                         </DropdownMenuItem>
-                                        <DropdownMenuItem>Send Message</DropdownMenuItem>
+                                        <DropdownMenuItem onClick={() => void handleSendMessage(contact)}>
+                                            Send Message
+                                        </DropdownMenuItem>
                                         <DropdownMenuItem>Send Money</DropdownMenuItem>
                                         <DropdownMenuItem onSelect={() => setManagingTagsContactId(contact.id)}>
                                             Edit Tags

--- a/app/welcome/[userId]/page.tsx
+++ b/app/welcome/[userId]/page.tsx
@@ -29,6 +29,7 @@ import {
 } from 'lucide-react';
 import axios from 'axios';
 import baseUrl from '@/helpers/baseUrl';
+import { createOrGetPreferredDmChat } from '@/services/secureChatService';
 import Navigation from '@/components/Navigation';
 import { Header } from '@/components/Header';
 import { useUserInfo } from '@/hooks/use-user-info';
@@ -1247,13 +1248,12 @@ const WelcomeProfilePage: React.FC = () => {
         return;
       }
 
-      const response = await axios.post(
-        `${baseUrl}/chats/dm`,
-        { participantId: userId },
-        { headers: { Authorization: `Bearer ${token}` } }
-      );
+      const result = await createOrGetPreferredDmChat({
+        token,
+        participantId: userId,
+      });
 
-      const chatId = response?.data?.data?.chatId;
+      const chatId = result?.chatId;
       if (chatId) {
         sessionStorage.setItem('pendingChatId', chatId);
       }

--- a/components/ClientProvider.tsx
+++ b/components/ClientProvider.tsx
@@ -16,6 +16,7 @@ import BrowserNotificationBadge from "@/components/notifications/BrowserNotifica
 import AuthSessionManager from "@/components/AuthSessionManager"
 import AppLockGate from "@/components/AppLockGate"
 import ChatNotificationSync from "@/components/ChatNotificationSync"
+import SecureDeviceBootstrap from "@/components/SecureDeviceBootstrap"
 
 const APP_LOCK_ENABLED = process.env.NEXT_PUBLIC_ENABLE_APP_LOCK === "true"
 const APP_LOCK_STORAGE_KEYS = ["qc:appLocked", "qc:lastActivityAt"]
@@ -36,6 +37,7 @@ const ClientProvider = ({ children }: { children: React.ReactNode }) => {
     return (
         <Provider store={store}>
             <AuthSessionManager />
+            <SecureDeviceBootstrap />
             <ThemeProvider>
                 {APP_LOCK_ENABLED ? <AppLockGate /> : null}
                 <NotificationProvider>

--- a/components/SecureDeviceBootstrap.tsx
+++ b/components/SecureDeviceBootstrap.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect } from "react";
+import { ensureRegisteredSecureDevice } from "@/services/e2eeDeviceService";
+import {
+  getStoredUserInfo,
+  getValidToken,
+  refreshAccessToken,
+} from "@/utils/tokenUtils";
+
+const runBootstrap = async () => {
+  const authUser = getStoredUserInfo();
+  if (!authUser?.id || authUser.accountType !== "user") {
+    return;
+  }
+
+  const token = getValidToken() || (await refreshAccessToken());
+  if (!token) {
+    return;
+  }
+
+  await ensureRegisteredSecureDevice({
+    token,
+    userId: authUser.id,
+  });
+};
+
+export default function SecureDeviceBootstrap() {
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    void runBootstrap();
+
+    const onResume = () => {
+      void runBootstrap();
+    };
+    const onTokenChanged = () => {
+      void runBootstrap();
+    };
+    const onVisibilityChange = () => {
+      if (!document.hidden) {
+        void runBootstrap();
+      }
+    };
+
+    window.addEventListener("online", onResume);
+    window.addEventListener("focus", onResume);
+    window.addEventListener("authTokenChanged", onTokenChanged as EventListener);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      window.removeEventListener("online", onResume);
+      window.removeEventListener("focus", onResume);
+      window.removeEventListener("authTokenChanged", onTokenChanged as EventListener);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, []);
+
+  return null;
+}

--- a/components/chat/chat-header.tsx
+++ b/components/chat/chat-header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
@@ -17,6 +17,8 @@ import { useGetGroupByIdQuery } from '@/states/groupSlice';
 import { useAuthToken } from '@/hooks/use-auth-token';
 import FundraisingProgressBadge from './fundraising-progress-badge';
 import { socketService } from '@/services/socketService';
+import { createOrGetSecureDmChat } from '@/services/secureChatService';
+import { toast } from '@/hooks/use-toast';
 import {
   ArrowLeft,
   Info,
@@ -48,8 +50,10 @@ export default function ChatHeader({
   onDeleteGroup,
 }: ChatHeaderProps) {
   const chat = useChat();
-  const { getToken } = useAuthToken();
+  const { getToken, getUserId } = useAuthToken();
   const token = getToken();
+  const userId = getUserId();
+  const [isOpeningSecureChat, setIsOpeningSecureChat] = useState(false);
 
   // Fetch group details if it's a group chat
   const { data: groupData, refetch: refetchGroupData } = useGetGroupByIdQuery(
@@ -58,6 +62,15 @@ export default function ChatHeader({
   );
 
   const group = groupData?.data;
+  const isDirectConversation = !conversation.isGroup && conversation.type !== 'support';
+  const isSecureConversation = conversation.securityMode === 'secure_dm_v1';
+  const secureParticipantId = useMemo(
+    () =>
+      isDirectConversation
+        ? conversation.participants.find((participant) => participant.userId !== userId)?.userId || null
+        : null,
+    [conversation.participants, isDirectConversation, userId],
+  );
 
   // Listen for real-time fundraising progress updates
   useEffect(() => {
@@ -92,6 +105,44 @@ export default function ChatHeader({
       .map(word => word[0])
       .join('')
       .toUpperCase();
+  };
+
+  const handleOpenSecureChat = async () => {
+    if (!token || !secureParticipantId) {
+      toast({
+        title: 'Secure chat unavailable',
+        description: 'Unable to resolve the other participant for this conversation.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    try {
+      setIsOpeningSecureChat(true);
+      const result = await createOrGetSecureDmChat({
+        token,
+        participantId: secureParticipantId,
+      });
+
+      chat.setActiveChat(result.chatId);
+      chat.refreshConversations();
+
+      toast({
+        title: result.chatId === conversation.id ? 'Secure chat already active' : 'Secure chat ready',
+        description:
+          result.chatId === conversation.id
+            ? 'This conversation is already using secure messaging.'
+            : 'You are now in the secure conversation thread.',
+      });
+    } catch (error: any) {
+      toast({
+        title: 'Secure chat unavailable',
+        description: error?.message || 'Failed to open the secure conversation.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsOpeningSecureChat(false);
+    }
   };
 
   return (
@@ -132,6 +183,15 @@ export default function ChatHeader({
             <h1 className='text-base sm:text-lg font-semibold text-gray-900 dark:text-white truncate'>
               {conversation.name || 'Unknown Contact'}
             </h1>
+            {isSecureConversation && (
+              <Badge
+                variant='secondary'
+                className='gap-1 border border-brand-green/20 bg-brand-green/10 text-brand-green'
+              >
+                <Lock size={12} />
+                Secure
+              </Badge>
+            )}
           </div>
 
           {/* Fundraising Progress for Groups */}
@@ -229,13 +289,23 @@ export default function ChatHeader({
               Chat Settings
             </DropdownMenuItem>
 
-            <DropdownMenuItem
-              onClick={() => chat.initializeEncryption()}
-              className='cursor-pointer'
-            >
-              <Lock size={14} className='mr-2' />
-              Initialize Encryption
-            </DropdownMenuItem>
+            {isDirectConversation && !isSecureConversation && (
+              <DropdownMenuItem
+                onClick={handleOpenSecureChat}
+                className='cursor-pointer'
+                disabled={isOpeningSecureChat}
+              >
+                <Lock size={14} className='mr-2' />
+                {isOpeningSecureChat ? 'Opening Secure Chat...' : 'Open Secure Chat'}
+              </DropdownMenuItem>
+            )}
+
+            {isDirectConversation && isSecureConversation && (
+              <DropdownMenuItem disabled className='cursor-default opacity-70'>
+                <Lock size={14} className='mr-2' />
+                Secure Chat Active
+              </DropdownMenuItem>
+            )}
 
             {/* Delete Group — only visible to owners and admins */}
             {conversation.isGroup &&

--- a/components/chat/start-chart-modal.tsx
+++ b/components/chat/start-chart-modal.tsx
@@ -6,7 +6,6 @@ import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Input } from "@/components/ui/input"
 import { Search, MessageCircle, Users, Loader2, AlertCircle } from "lucide-react"
-import { toast } from "@/hooks/use-toast"
 import { useGetAcceptedContactsQuery } from "@/states/contactSlice"
 import { useAuthToken } from "@/hooks/use-auth-token"
 import type { Conversation } from "@/types/chat.types"
@@ -14,7 +13,7 @@ import type { Conversation } from "@/types/chat.types"
 interface StartChatModalProps {
   isOpen: boolean
   onClose: () => void
-  onStartChat: (contact: any) => void
+  onStartChat: (contact: any) => Promise<void> | void
   existingConversations: Conversation[]
 }
 
@@ -47,14 +46,10 @@ export default function StartChatModal({ isOpen, onClose, onStartChat, existingC
     return fullName.includes(search) || email.includes(search)
   })
 
-  const handleStartChat = (contact: any) => {
-    onStartChat(contact)
+  const handleStartChat = async (contact: any) => {
+    await Promise.resolve(onStartChat(contact))
     onClose()
     setSearchTerm("")
-    toast({
-      title: "Chat Started",
-      description: `Started a new conversation with ${contact.otherUser.firstName} ${contact.otherUser.lastName}`,
-    })
   }
 
   const handleClose = () => {
@@ -143,7 +138,7 @@ export default function StartChatModal({ isOpen, onClose, onStartChat, existingC
                   <div
                     key={contact.id}
                     className='flex items-center justify-between p-3 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors cursor-pointer group'
-                    onClick={() => handleStartChat(contact)}
+                    onClick={() => void handleStartChat(contact)}
                   >
                     <div className='flex items-center flex-1'>
                       <Avatar className='h-12 w-12 mr-3'>
@@ -176,7 +171,7 @@ export default function StartChatModal({ isOpen, onClose, onStartChat, existingC
                       className='opacity-0 group-hover:opacity-100 transition-opacity'
                       onClick={e => {
                         e.stopPropagation();
-                        handleStartChat(contact);
+                        void handleStartChat(contact);
                       }}
                     >
                       <MessageCircle size={16} className='mr-2' />

--- a/context/ChatContext.tsx
+++ b/context/ChatContext.tsx
@@ -16,6 +16,11 @@ import {
 } from "@/types/chat.types";
 import { toast } from "@/hooks/use-toast";
 import { notificationService } from "@/services/notificationService";
+import {
+    fetchSecureChatMessages,
+    markSecureChatAsRead,
+    sendSecureTextMessage,
+} from "@/services/secureChatService";
 
 interface ChatContextType {
     isConnected: boolean;
@@ -71,6 +76,12 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
     const [typingUsers, setTypingUsers] = useState<TypingUser[]>([]);
     const [onlineUsers, setOnlineUsers] = useState<OnlineUser[]>([]);
     const [participantsStatus, setParticipantsStatus] = useState<Record<string, ChatParticipantStatus[]>>({});
+    const [secureMessagesRefreshKey, setSecureMessagesRefreshKey] = useState(0);
+
+    const activeConversation = activeChat
+        ? conversations.find((conversation) => conversation.id === activeChat) || null
+        : null;
+    const isActiveSecureChat = activeConversation?.securityMode === "secure_dm_v1";
 
     const isSupportConversation = useCallback((conv: Conversation) => {
         if ((conv as any).type === 'support') return true;
@@ -147,7 +158,7 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
 
     const { data: messagesData, refetch: refetchMessages } = useGetChatMessagesQuery(
         { chatId: activeChat || '', page: 1, limit: 50 },
-        { skip: !activeChat || !token }
+        { skip: !activeChat || !token || isActiveSecureChat }
     );
 
     useEffect(() => {
@@ -262,6 +273,64 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
                 content: message.content,
                 messageType: message.messageType as any,
             });
+        };
+
+        const handleSecureMessageAvailable = (data: {
+            chatId: string;
+            messageId: string;
+            senderId: string;
+            sender: { id: string; name: string; firstName?: string; lastName?: string };
+            messageType: "text";
+            securityMode: "secure_dm_v1";
+            createdAt: string;
+        }) => {
+            const conversation = conversations.find((item) => item.id === data.chatId);
+            if (!conversation || conversation.securityMode !== "secure_dm_v1") {
+                refetchChats();
+                return;
+            }
+
+            if (data.chatId === activeChat) {
+                setSecureMessagesRefreshKey((current) => current + 1);
+            }
+
+            setConversations((prev: Conversation[]) => {
+                const updatedConversations = prev.map((conv: Conversation) => {
+                    if (conv.id !== data.chatId) return conv;
+
+                    const shouldIncrementUnread =
+                        data.senderId !== userId &&
+                        conv.id !== activeChat;
+
+                    return {
+                        ...conv,
+                        lastMessage: {
+                            content: "Secure message",
+                            messageType: "text",
+                            createdAt: data.createdAt,
+                            sender: data.sender.name,
+                        },
+                        timestamp: data.createdAt,
+                        unreadCount: shouldIncrementUnread
+                            ? (conv.unreadCount || 0) + 1
+                            : (conv.unreadCount || 0),
+                    };
+                });
+
+                return updatedConversations.sort(sortConversations);
+            });
+
+            if (data.senderId !== userId) {
+                notificationService.notifyNewMessage({
+                    chatId: data.chatId,
+                    senderId: data.senderId,
+                    senderName: data.sender.lastName || data.sender.name,
+                    content: "Secure message",
+                    messageType: "text",
+                });
+            }
+
+            refetchChats();
         };
 
         const handleMessageDelivered = (data: { chatId: string; messageId: string; deliveredAt: Date }) => {
@@ -451,6 +520,7 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
         };
 
         socketService.onNewMessage(handleNewMessage);
+        socketService.onSecureMessageAvailable(handleSecureMessageAvailable);
         socketService.onMessageDelivered(handleMessageDelivered);
         socketService.onMessagesRead(handleMessagesRead);
         socketService.onUserTyping(handleUserTyping);
@@ -469,6 +539,7 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
 
         return () => {
             socketService.offNewMessage(handleNewMessage);
+            socketService.offSecureMessageAvailable(handleSecureMessageAvailable);
             socketService.offMessageDelivered(handleMessageDelivered);
             socketService.offMessagesRead(handleMessagesRead);
             socketService.offUserTyping(handleUserTyping);
@@ -484,22 +555,34 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
             socketService.offPaymentRequestUpdated(handlePaymentRequestUpdated);
             socketService.offReactionUpdated(handleReactionUpdated);
         };
-    }, [isConnected, activeChat, userId, refetchMessages, sortConversations]);
+    }, [isConnected, activeChat, userId, refetchMessages, sortConversations, conversations, token, refetchChats]);
 
     useEffect(() => {
-        if (activeChat && isConnected) {
+        if (!activeChat) return;
+
+        notificationService.setActiveChat(activeChat);
+
+        setConversations((prev: Conversation[]) => prev.map((conv: Conversation) =>
+            conv.id === activeChat
+                ? { ...conv, unreadCount: 0 }
+                : conv
+        ));
+
+        if (isActiveSecureChat) {
+            if (token && userId) {
+                void markSecureChatAsRead({ token, userId, chatId: activeChat }).catch((error) => {
+                    console.error("Failed to mark secure chat as read", error);
+                });
+            }
+
+            return () => {
+                notificationService.setActiveChat(null);
+            };
+        }
+
+        if (isConnected) {
             socketService.joinChat(activeChat);
             socketService.markMessageRead(activeChat, '');
-            
-            // Update notification service with active chat
-            notificationService.setActiveChat(activeChat);
-
-            // Reset unread count for active chat
-            setConversations((prev: Conversation[]) => prev.map((conv: Conversation) =>
-                conv.id === activeChat
-                    ? { ...conv, unreadCount: 0 } // ...conv already preserves all fields
-                    : conv
-            ));
 
             return () => {
                 if (activeChat) {
@@ -508,7 +591,11 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
                 }
             };
         }
-    }, [activeChat, isConnected]);
+
+        return () => {
+            notificationService.setActiveChat(null);
+        };
+    }, [activeChat, isConnected, isActiveSecureChat, token, userId]);
 
     useEffect(() => {
         if (chatsData?.data) {
@@ -519,6 +606,10 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
     }, [chatsData, sortConversations]);
 
     useEffect(() => {
+        if (isActiveSecureChat) {
+            return;
+        }
+
         if (messagesData?.data?.messages && activeChat) {
             const messagesWithIsMe = messagesData.data.messages.map((msg: Message) => ({
                 ...msg,
@@ -530,7 +621,71 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
                 [activeChat]: messagesWithIsMe
             }));
         }
-    }, [messagesData, activeChat, userId]);
+    }, [messagesData, activeChat, userId, isActiveSecureChat]);
+
+    useEffect(() => {
+        if (!activeChat || !token || !userId || !isActiveSecureChat) {
+            return;
+        }
+
+        let cancelled = false;
+
+        const loadSecureMessages = async () => {
+            try {
+                const secureMessages = await fetchSecureChatMessages({
+                    token,
+                    userId,
+                    chatId: activeChat,
+                });
+
+                if (cancelled) return;
+
+                setMessages((prev: Record<string, Message[]>) => ({
+                    ...prev,
+                    [activeChat]: secureMessages.map((message) => ({
+                        ...message,
+                        isMe: String(message.sender.id) === String(userId),
+                    })),
+                }));
+
+                await markSecureChatAsRead({ token, userId, chatId: activeChat });
+            } catch (error) {
+                console.error("Failed to load secure chat messages", error);
+            }
+        };
+
+        void loadSecureMessages();
+        const interval = window.setInterval(() => {
+            void loadSecureMessages();
+        }, 5000);
+
+        return () => {
+            cancelled = true;
+            window.clearInterval(interval);
+        };
+    }, [activeChat, token, userId, isActiveSecureChat, secureMessagesRefreshKey]);
+
+    useEffect(() => {
+        if (!token || !userId) {
+            return;
+        }
+
+        const hasSecureConversations = conversations.some(
+            (conversation) => conversation.securityMode === "secure_dm_v1",
+        );
+
+        if (!hasSecureConversations) {
+            return;
+        }
+
+        const interval = window.setInterval(() => {
+            refetchChats();
+        }, 10000);
+
+        return () => {
+            window.clearInterval(interval);
+        };
+    }, [token, userId, conversations, refetchChats]);
 
     const refreshConversations = useCallback(() => {
         refetchChats();
@@ -538,9 +693,13 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
 
     const refreshMessages = useCallback((chatId: string) => {
         if (chatId === activeChat) {
+            if (activeConversation?.securityMode === "secure_dm_v1") {
+                setSecureMessagesRefreshKey((current) => current + 1);
+                return;
+            }
             refetchMessages();
         }
-    }, [activeChat, refetchMessages]);
+    }, [activeChat, activeConversation?.securityMode, refetchMessages]);
 
     const sendMessage = useCallback((
         chatId: string,
@@ -550,13 +709,109 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
         replyToMessageId?: string,
         replyTo?: ReplyPreview | null
     ) => {
-        if (isConnected && content.trim()) {
-            socketService.sendMessage(chatId, content.trim(), messageType, undefined, mentions, replyToMessageId);
+        const trimmedContent = content.trim();
+        if (!trimmedContent) {
+            return;
+        }
+
+        const conversation = conversations.find((item) => item.id === chatId);
+        if (conversation?.securityMode === "secure_dm_v1") {
+            if (messageType !== "text") {
+                toast({
+                    title: "Not available yet",
+                    description: "secure_dm_v1 currently supports text messages only.",
+                    variant: "destructive",
+                });
+                return;
+            }
+
+            if (!token || !userId) {
+                toast({
+                    title: "Secure chat unavailable",
+                    description: "Your session is not ready for secure messaging yet.",
+                    variant: "destructive",
+                });
+                return;
+            }
+
+            const tempMessageId = `temp_secure_${Date.now()}`;
+            const tempMessage: Message = {
+                id: tempMessageId,
+                chatId,
+                content: trimmedContent,
+                messageType: "text",
+                replyToMessageId: replyToMessageId || null,
+                replyTo: replyTo || null,
+                reactions: [],
+                status: 'sent',
+                createdAt: new Date().toISOString(),
+                sender: {
+                    id: userId,
+                    name: 'You',
+                    avatar: undefined
+                },
+                isMe: true,
+                mentions,
+            };
+
+            setMessages((prev: Record<string, Message[]>) => ({
+                ...prev,
+                [chatId]: [...(prev[chatId] || []), tempMessage]
+            }));
+
+            setConversations((prev: Conversation[]) => {
+                const updatedConversations = prev.map((conv: Conversation) =>
+                    conv.id === chatId
+                        ? {
+                            ...conv,
+                            lastMessage: {
+                                content: "Secure message",
+                                messageType: "text" as const,
+                                createdAt: tempMessage.createdAt,
+                                sender: "You"
+                            },
+                            timestamp: tempMessage.createdAt
+                        }
+                        : conv
+                );
+
+                return updatedConversations.sort(sortConversations);
+            });
+
+            void (async () => {
+                try {
+                    await sendSecureTextMessage({
+                        token,
+                        userId,
+                        chatId,
+                        conversation,
+                        content: trimmedContent,
+                        replyToMessageId: replyToMessageId || undefined,
+                    });
+                    setSecureMessagesRefreshKey((current) => current + 1);
+                    refetchChats();
+                } catch (error: any) {
+                    setMessages((prev: Record<string, Message[]>) => ({
+                        ...prev,
+                        [chatId]: (prev[chatId] || []).filter((message) => message.id !== tempMessageId)
+                    }));
+                    toast({
+                        title: "Secure message failed",
+                        description: error?.message || "Failed to send secure message",
+                        variant: "destructive",
+                    });
+                }
+            })();
+            return;
+        }
+
+        if (isConnected) {
+            socketService.sendMessage(chatId, trimmedContent, messageType, undefined, mentions, replyToMessageId);
 
             const tempMessage: Message = {
                 id: `temp_${Date.now()}`,
                 chatId,
-                content: content.trim(),
+                content: trimmedContent,
                 messageType,
                 replyToMessageId: replyToMessageId || null,
                 replyTo: replyTo || null,
@@ -585,7 +840,7 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
                         ? {
                             ...conv, // Preserve all fields including groupId
                             lastMessage: {
-                                content: content.trim(),
+                                content: trimmedContent,
                                 messageType,
                                 createdAt: new Date().toISOString(),
                                 sender: 'You'
@@ -599,13 +854,23 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
                 return updatedConversations.sort(sortConversations);
             });
         }
-    }, [isConnected, userId, sortConversations]);
+    }, [isConnected, userId, token, conversations, sortConversations, refetchChats]);
 
     const markMessagesAsRead = useCallback((chatId: string) => {
+        const conversation = conversations.find((item) => item.id === chatId);
+        if (conversation?.securityMode === "secure_dm_v1") {
+            if (token && userId) {
+                void markSecureChatAsRead({ token, userId, chatId }).catch((error) => {
+                    console.error("Failed to mark secure chat as read", error);
+                });
+            }
+            return;
+        }
+
         if (isConnected) {
             socketService.markMessageRead(chatId, '');
         }
-    }, [isConnected]);
+    }, [conversations, isConnected, token, userId]);
 
     const startTyping = useCallback((chatId: string) => {
         if (isConnected) {
@@ -646,8 +911,17 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
     }, []);
 
     const markMessageRead = useCallback((chatId: string, messageId: string) => {
+        const conversation = conversations.find((item) => item.id === chatId);
+        if (conversation?.securityMode === "secure_dm_v1") {
+            if (token && userId) {
+                void markSecureChatAsRead({ token, userId, chatId }).catch((error) => {
+                    console.error("Failed to mark secure chat as read", error);
+                });
+            }
+            return;
+        }
         socketService.markMessageRead(chatId, messageId);
-    }, []);
+    }, [conversations, token, userId]);
 
     const addMessage = useCallback((message: Message) => {
         setMessages((prev: Record<string, Message[]>) => {

--- a/context/ChatContext.tsx
+++ b/context/ChatContext.tsx
@@ -306,7 +306,7 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
                         ...conv,
                         lastMessage: {
                             content: "Secure message",
-                            messageType: "text",
+                            messageType: "text" as const,
                             createdAt: data.createdAt,
                             sender: data.sender.name,
                         },
@@ -326,7 +326,7 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
                     senderId: data.senderId,
                     senderName: data.sender.lastName || data.sender.name,
                     content: "Secure message",
-                    messageType: "text",
+                    messageType: "text" as const,
                 });
             }
 

--- a/hooks/use-chat-operations.ts
+++ b/hooks/use-chat-operations.ts
@@ -5,7 +5,6 @@ import { useAuthToken } from '@/hooks/use-auth-token';
 import { useChat } from '@/context/ChatContext';
 import {
     useGetUserChatsQuery,
-    useCreateOrGetDMChatMutation,
     useSendMessageMutation,
     useMarkMessagesAsReadMutation,
     useCreateGroupChatMutation,
@@ -14,6 +13,7 @@ import {
 } from '@/states/chatSlice';
 import { toast } from '@/hooks/use-toast';
 import { parseMessageContent } from '@/utils/messageUtils';
+import { createOrGetPreferredDmChat } from '@/services/secureChatService';
 import type {
     Chat,
     Message,
@@ -64,8 +64,6 @@ export function useChatOperations(): UseChatOperationsReturn {
         skip: !token,
     });
 
-    const [createOrGetDMChat, { isLoading: isCreatingDMChat }] =
-        useCreateOrGetDMChatMutation();
     const [sendMessage, { isLoading: isSendingMessage }] =
         useSendMessageMutation();
     const [markAsRead] = useMarkMessagesAsReadMutation();
@@ -104,6 +102,8 @@ export function useChatOperations(): UseChatOperationsReturn {
             name: conv.name,
             isGroup: conv.isGroup,
             type: conv.type,
+            securityMode: conv.securityMode,
+            protocolVersion: conv.protocolVersion,
             groupId: conv.groupId, // Include groupId
             lastMessage: conv.lastMessage?.content ? {
                 content: parseMessageContent(conv.lastMessage.content, conv.lastMessage.messageType),
@@ -127,6 +127,8 @@ export function useChatOperations(): UseChatOperationsReturn {
             name: chat.name,
             isGroup: chat.isGroup,
             type: chat.type,
+            securityMode: chat.securityMode,
+            protocolVersion: chat.protocolVersion,
             groupId: chat.groupId, // Include groupId
             lastMessage: chat.lastMessage ? {
                 content: parseMessageContent(chat.lastMessage.content, chat.lastMessage.messageType),
@@ -150,26 +152,33 @@ export function useChatOperations(): UseChatOperationsReturn {
 
     const handleStartNewChat = useCallback(async (contact: any) => {
         try {
-            const result = await createOrGetDMChat({
-                participantId: contact.otherUser.id
-            }).unwrap()
+            if (!token) {
+                throw new Error("Authentication required");
+            }
 
-            setContextActiveChat(result.data.chatId)
+            const result = await createOrGetPreferredDmChat({
+                token,
+                participantId: contact.otherUser.id,
+            });
+
+            setContextActiveChat(result.chatId)
 
             toast({
-                title: "Chat Started",
-                description: `Started a new conversation with ${contact.otherUser.firstName} ${contact.otherUser.lastName}`,
+                title: result.usedSecure ? "Secure Chat Started" : "Chat Started",
+                description: result.usedSecure
+                    ? `Started a secure conversation with ${contact.otherUser.firstName} ${contact.otherUser.lastName}`
+                    : `Started a new conversation with ${contact.otherUser.firstName} ${contact.otherUser.lastName}`,
             })
 
             contextRefreshConversations?.()
         } catch (error: any) {
             toast({
                 title: "Error",
-                description: error.data?.message || "Failed to start chat",
+                description: error?.data?.message || error?.message || "Failed to start chat",
                 variant: "destructive"
             })
         }
-    }, [createOrGetDMChat, setContextActiveChat, contextRefreshConversations])
+    }, [token, setContextActiveChat, contextRefreshConversations])
 
     const handleJoinGroup = useCallback(async (group: any) => {
         try {
@@ -253,7 +262,7 @@ export function useChatOperations(): UseChatOperationsReturn {
         conversations,
         activeChat,
         messages,
-        isLoading: chatsLoading || isCreatingDMChat || isSendingMessage || isCreatingGroup || isJoiningGroup,
+        isLoading: chatsLoading || isSendingMessage || isCreatingGroup || isJoiningGroup,
         isConnected,
         typingUsers,
         onlineUsers,

--- a/lib/e2ee/deviceStore.ts
+++ b/lib/e2ee/deviceStore.ts
@@ -1,0 +1,116 @@
+import type { StoredSecureDeviceState } from "@/types/e2ee.types";
+
+const DB_NAME = "qc-secure-chat";
+const DB_VERSION = 1;
+const STORE_NAME = "deviceState";
+const FALLBACK_STORAGE_KEY = "qc:secure-device-state";
+
+const canUseIndexedDb = () =>
+  typeof window !== "undefined" && typeof window.indexedDB !== "undefined";
+
+const openDb = async (): Promise<IDBDatabase> =>
+  new Promise((resolve, reject) => {
+    const request = window.indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("Failed to open IndexedDB"));
+  });
+
+const withStore = async <T>(
+  mode: IDBTransactionMode,
+  run: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T | undefined> => {
+  const db = await openDb();
+
+  return new Promise<T | undefined>((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, mode);
+    const store = transaction.objectStore(STORE_NAME);
+    const request = run(store);
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed"));
+    transaction.oncomplete = () => db.close();
+    transaction.onerror = () => {
+      db.close();
+      reject(transaction.error ?? new Error("IndexedDB transaction failed"));
+    };
+  });
+};
+
+const readFallbackState = (): StoredSecureDeviceState | null => {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const raw = window.localStorage.getItem(FALLBACK_STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as StoredSecureDeviceState) : null;
+  } catch {
+    return null;
+  }
+};
+
+const writeFallbackState = (state: StoredSecureDeviceState | null) => {
+  if (typeof window === "undefined") return;
+
+  if (!state) {
+    window.localStorage.removeItem(FALLBACK_STORAGE_KEY);
+    return;
+  }
+
+  window.localStorage.setItem(FALLBACK_STORAGE_KEY, JSON.stringify(state));
+};
+
+export const getStoredSecureDeviceState = async (): Promise<StoredSecureDeviceState | null> => {
+  if (typeof window === "undefined") return null;
+
+  if (!canUseIndexedDb()) {
+    return readFallbackState();
+  }
+
+  try {
+    const state = await withStore<StoredSecureDeviceState>("readonly", (store) =>
+      store.get("active"),
+    );
+    return state ?? null;
+  } catch {
+    return readFallbackState();
+  }
+};
+
+export const saveStoredSecureDeviceState = async (state: StoredSecureDeviceState) => {
+  if (typeof window === "undefined") return;
+
+  if (!canUseIndexedDb()) {
+    writeFallbackState(state);
+    return;
+  }
+
+  try {
+    await withStore("readwrite", (store) => store.put(state, "active"));
+    writeFallbackState(state);
+  } catch {
+    writeFallbackState(state);
+  }
+};
+
+export const clearStoredSecureDeviceState = async () => {
+  if (typeof window === "undefined") return;
+
+  if (!canUseIndexedDb()) {
+    writeFallbackState(null);
+    return;
+  }
+
+  try {
+    await withStore("readwrite", (store) => store.delete("active"));
+    writeFallbackState(null);
+  } catch {
+    writeFallbackState(null);
+  }
+};

--- a/lib/e2ee/secureMessageCrypto.ts
+++ b/lib/e2ee/secureMessageCrypto.ts
@@ -1,0 +1,360 @@
+"use client";
+
+import type {
+  PublicSecureDeviceBundle,
+  SecureEncryptedEnvelope,
+  SecureRecipientPayload,
+  StoredSecureDeviceState,
+  SupportedE2EEAlgorithm,
+} from "@/types/e2ee.types";
+
+const SUPPORTED_ALGORITHM: SupportedE2EEAlgorithm = "qc-e2ee-p256-v1";
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const stableStringify = (value: unknown): string => {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+
+  return `{${entries
+    .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+    .join(",")}}`;
+};
+
+const toBase64Url = (value: ArrayBuffer | Uint8Array) => {
+  const bytes = value instanceof Uint8Array ? value : new Uint8Array(value);
+  let binary = "";
+
+  for (let index = 0; index < bytes.length; index += 1) {
+    binary += String.fromCharCode(bytes[index]);
+  }
+
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+};
+
+const fromBase64Url = (value: string) => {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+
+  return bytes;
+};
+
+const importIdentityPrivateKey = (jwk: JsonWebKey) =>
+  window.crypto.subtle.importKey(
+    "jwk",
+    jwk,
+    {
+      name: "ECDSA",
+      namedCurve: "P-256",
+    },
+    true,
+    ["sign"],
+  );
+
+const importIdentityPublicKey = (jwk: JsonWebKey) =>
+  window.crypto.subtle.importKey(
+    "jwk",
+    jwk,
+    {
+      name: "ECDSA",
+      namedCurve: "P-256",
+    },
+    true,
+    ["verify"],
+  );
+
+const importExchangePrivateKey = (jwk: JsonWebKey) =>
+  window.crypto.subtle.importKey(
+    "jwk",
+    jwk,
+    {
+      name: "ECDH",
+      namedCurve: "P-256",
+    },
+    true,
+    ["deriveBits"],
+  );
+
+const importExchangePublicKey = (jwk: JsonWebKey) =>
+  window.crypto.subtle.importKey(
+    "jwk",
+    jwk,
+    {
+      name: "ECDH",
+      namedCurve: "P-256",
+    },
+    true,
+    [],
+  );
+
+const deriveWrappingKey = async ({
+  privateKey,
+  publicKey,
+  senderDeviceId,
+  recipientDeviceId,
+}: {
+  privateKey: CryptoKey;
+  publicKey: CryptoKey;
+  senderDeviceId: string;
+  recipientDeviceId: string;
+}) => {
+  const sharedSecret = await window.crypto.subtle.deriveBits(
+    {
+      name: "ECDH",
+      public: publicKey,
+    },
+    privateKey,
+    256,
+  );
+
+  const hkdfKey = await window.crypto.subtle.importKey("raw", sharedSecret, "HKDF", false, [
+    "deriveKey",
+  ]);
+
+  return window.crypto.subtle.deriveKey(
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt: encoder.encode("qc-secure-dm-v1-salt"),
+      info: encoder.encode(`${senderDeviceId}:${recipientDeviceId}:message-wrap`),
+    },
+    hkdfKey,
+    {
+      name: "AES-GCM",
+      length: 256,
+    },
+    false,
+    ["encrypt", "decrypt"],
+  );
+};
+
+const signEnvelopePayload = async (
+  identityPrivateKey: CryptoKey,
+  payload: Omit<SecureEncryptedEnvelope, "signature">,
+) => {
+  const signature = await window.crypto.subtle.sign(
+    {
+      name: "ECDSA",
+      hash: "SHA-256",
+    },
+    identityPrivateKey,
+    encoder.encode(stableStringify(payload)),
+  );
+
+  return toBase64Url(signature);
+};
+
+const verifyEnvelopePayload = async ({
+  identityPublicKey,
+  payload,
+}: {
+  identityPublicKey: JsonWebKey;
+  payload: SecureEncryptedEnvelope;
+}) => {
+  const cryptoKey = await importIdentityPublicKey(identityPublicKey);
+  const { signature, ...unsignedPayload } = payload;
+  return window.crypto.subtle.verify(
+    {
+      name: "ECDSA",
+      hash: "SHA-256",
+    },
+    cryptoKey,
+    fromBase64Url(signature),
+    encoder.encode(stableStringify(unsignedPayload)),
+  );
+};
+
+const verifySignedPreKey = async (bundle: PublicSecureDeviceBundle) => {
+  const identityKey = await importIdentityPublicKey(bundle.bundle.identityPublicKey);
+  return window.crypto.subtle.verify(
+    {
+      name: "ECDSA",
+      hash: "SHA-256",
+    },
+    identityKey,
+    fromBase64Url(bundle.bundle.signedPreKeySignature),
+    encoder.encode(stableStringify(bundle.bundle.signedPreKeyPublic)),
+  );
+};
+
+export const encryptSecureTextForRecipients = async ({
+  content,
+  senderUserId,
+  senderState,
+  recipientDevices,
+}: {
+  content: string;
+  senderUserId: string;
+  senderState: StoredSecureDeviceState;
+  recipientDevices: PublicSecureDeviceBundle[];
+}) => {
+  if (!content.trim()) {
+    throw new Error("Cannot encrypt an empty secure message");
+  }
+
+  const identityPrivateKey = await importIdentityPrivateKey(senderState.identity.privateKey);
+  const rawMessageKey = window.crypto.getRandomValues(new Uint8Array(32));
+  const messageKey = await window.crypto.subtle.importKey(
+    "raw",
+    rawMessageKey,
+    "AES-GCM",
+    true,
+    ["encrypt", "decrypt"],
+  );
+  const ciphertextIv = window.crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = await window.crypto.subtle.encrypt(
+    {
+      name: "AES-GCM",
+      iv: ciphertextIv,
+    },
+    messageKey,
+    encoder.encode(content),
+  );
+
+  const createdAt = new Date().toISOString();
+  const recipientPayloads: SecureRecipientPayload[] = [];
+
+  for (const recipientDevice of recipientDevices) {
+    if (!(await verifySignedPreKey(recipientDevice))) {
+      throw new Error(`Secure device bundle verification failed for ${recipientDevice.deviceId}`);
+    }
+
+    const ephemeralKeyPair = await window.crypto.subtle.generateKey(
+      {
+        name: "ECDH",
+        namedCurve: "P-256",
+      },
+      true,
+      ["deriveBits"],
+    );
+    const recipientPublicKey = await importExchangePublicKey(
+      recipientDevice.bundle.signedPreKeyPublic,
+    );
+    const wrappingKey = await deriveWrappingKey({
+      privateKey: ephemeralKeyPair.privateKey,
+      publicKey: recipientPublicKey,
+      senderDeviceId: senderState.deviceId,
+      recipientDeviceId: recipientDevice.deviceId,
+    });
+    const wrappingIv = window.crypto.getRandomValues(new Uint8Array(12));
+    const wrappedMessageKey = await window.crypto.subtle.encrypt(
+      {
+        name: "AES-GCM",
+        iv: wrappingIv,
+      },
+      wrappingKey,
+      rawMessageKey,
+    );
+    const ephemeralPublicKey = (await window.crypto.subtle.exportKey(
+      "jwk",
+      ephemeralKeyPair.publicKey,
+    )) as JsonWebKey;
+
+    const unsignedEnvelope: Omit<SecureEncryptedEnvelope, "signature"> = {
+      version: 1,
+      protocolVersion: "secure-dm-v1",
+      algorithm: SUPPORTED_ALGORITHM,
+      senderUserId,
+      senderDeviceId: senderState.deviceId,
+      recipientUserId: recipientDevice.userId,
+      recipientDeviceId: recipientDevice.deviceId,
+      ephemeralPublicKey,
+      wrappedMessageKey: toBase64Url(wrappedMessageKey),
+      wrappedMessageKeyIv: toBase64Url(wrappingIv),
+      ciphertext: toBase64Url(ciphertext),
+      ciphertextIv: toBase64Url(ciphertextIv),
+      createdAt,
+    };
+    const signature = await signEnvelopePayload(identityPrivateKey, unsignedEnvelope);
+
+    recipientPayloads.push({
+      recipientUserId: recipientDevice.userId,
+      recipientDeviceId: recipientDevice.deviceId,
+      encryptedEnvelope: {
+        ...unsignedEnvelope,
+        signature,
+      },
+    });
+  }
+
+  return {
+    createdAt,
+    recipientPayloads,
+  };
+};
+
+export const decryptSecureEnvelope = async ({
+  envelope,
+  senderIdentityPublicKey,
+  recipientState,
+}: {
+  envelope: SecureEncryptedEnvelope;
+  senderIdentityPublicKey: JsonWebKey;
+  recipientState: StoredSecureDeviceState;
+}) => {
+  if (envelope.algorithm !== SUPPORTED_ALGORITHM) {
+    throw new Error("Unsupported secure message algorithm");
+  }
+
+  if (envelope.recipientDeviceId !== recipientState.deviceId) {
+    throw new Error("Secure message envelope does not target this device");
+  }
+
+  const isAuthentic = await verifyEnvelopePayload({
+    identityPublicKey: senderIdentityPublicKey,
+    payload: envelope,
+  });
+
+  if (!isAuthentic) {
+    throw new Error("Secure message signature verification failed");
+  }
+
+  const signedPreKeyPrivate = await importExchangePrivateKey(recipientState.signedPreKey.privateKey);
+  const ephemeralPublicKey = await importExchangePublicKey(envelope.ephemeralPublicKey);
+  const wrappingKey = await deriveWrappingKey({
+    privateKey: signedPreKeyPrivate,
+    publicKey: ephemeralPublicKey,
+    senderDeviceId: envelope.senderDeviceId,
+    recipientDeviceId: envelope.recipientDeviceId,
+  });
+  const rawMessageKey = await window.crypto.subtle.decrypt(
+    {
+      name: "AES-GCM",
+      iv: fromBase64Url(envelope.wrappedMessageKeyIv),
+    },
+    wrappingKey,
+    fromBase64Url(envelope.wrappedMessageKey),
+  );
+  const messageKey = await window.crypto.subtle.importKey(
+    "raw",
+    rawMessageKey,
+    "AES-GCM",
+    false,
+    ["decrypt"],
+  );
+  const plaintext = await window.crypto.subtle.decrypt(
+    {
+      name: "AES-GCM",
+      iv: fromBase64Url(envelope.ciphertextIv),
+    },
+    messageKey,
+    fromBase64Url(envelope.ciphertext),
+  );
+
+  return decoder.decode(plaintext);
+};

--- a/services/e2eeDeviceService.ts
+++ b/services/e2eeDeviceService.ts
@@ -1,0 +1,266 @@
+"use client";
+
+import baseUrl from "@/helpers/baseUrl";
+import {
+  clearStoredSecureDeviceState,
+  getStoredSecureDeviceState,
+  saveStoredSecureDeviceState,
+} from "@/lib/e2ee/deviceStore";
+import type {
+  PublicPreKey,
+  SecureDeviceBundlePayload,
+  StoredOneTimePreKey,
+  StoredSecureDeviceState,
+  SupportedE2EEAlgorithm,
+} from "@/types/e2ee.types";
+
+const ACTIVE_APP_VERSION = "web-pwa-v1";
+const ONE_TIME_PREKEY_COUNT = 12;
+const SYNC_INTERVAL_MS = 12 * 60 * 60 * 1000;
+const SUPPORTED_ALGORITHM: SupportedE2EEAlgorithm = "qc-e2ee-p256-v1";
+
+const encoder = new TextEncoder();
+
+const stableStringify = (value: unknown): string => {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+
+  return `{${entries
+    .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+    .join(",")}}`;
+};
+
+const toBase64Url = (buffer: ArrayBuffer) => {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+
+  for (let index = 0; index < bytes.length; index += 1) {
+    binary += String.fromCharCode(bytes[index]);
+  }
+
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+};
+
+const getRandomId = () => window.crypto.getRandomValues(new Uint32Array(1))[0] ?? Date.now();
+
+const describeCurrentDevice = () => {
+  const nav = window.navigator as Navigator & {
+    userAgentData?: { platform?: string; brands?: Array<{ brand: string; version: string }> };
+  };
+
+  const platform = nav.userAgentData?.platform || nav.platform || "web";
+  const browser =
+    nav.userAgentData?.brands?.[0]?.brand ||
+    (/Chrome/i.test(nav.userAgent)
+      ? "Chrome"
+      : /Edg/i.test(nav.userAgent)
+        ? "Edge"
+        : /Firefox/i.test(nav.userAgent)
+          ? "Firefox"
+          : "Browser");
+  const mode = window.matchMedia?.("(display-mode: standalone)")?.matches ? "PWA" : "Browser";
+
+  return {
+    platform,
+    deviceName: `${mode} ${browser}`.trim(),
+  };
+};
+
+const generateSigningKeyPair = () =>
+  window.crypto.subtle.generateKey(
+    {
+      name: "ECDSA",
+      namedCurve: "P-256",
+    },
+    true,
+    ["sign", "verify"],
+  );
+
+const generateExchangeKeyPair = () =>
+  window.crypto.subtle.generateKey(
+    {
+      name: "ECDH",
+      namedCurve: "P-256",
+    },
+    true,
+    ["deriveBits"],
+  );
+
+const exportPrivatePublicPair = async (keyPair: CryptoKeyPair) => ({
+  publicKey: (await window.crypto.subtle.exportKey("jwk", keyPair.publicKey)) as JsonWebKey,
+  privateKey: (await window.crypto.subtle.exportKey("jwk", keyPair.privateKey)) as JsonWebKey,
+});
+
+const signSignedPreKey = async (
+  identityPrivateKey: CryptoKey,
+  signedPreKeyPublic: JsonWebKey,
+) => {
+  const signature = await window.crypto.subtle.sign(
+    {
+      name: "ECDSA",
+      hash: "SHA-256",
+    },
+    identityPrivateKey,
+    encoder.encode(stableStringify(signedPreKeyPublic)),
+  );
+
+  return toBase64Url(signature);
+};
+
+const generateOneTimePreKeys = async (): Promise<StoredOneTimePreKey[]> => {
+  const keys: StoredOneTimePreKey[] = [];
+
+  for (let index = 0; index < ONE_TIME_PREKEY_COUNT; index += 1) {
+    const keyPair = await generateExchangeKeyPair();
+    const exported = await exportPrivatePublicPair(keyPair);
+
+    keys.push({
+      keyId: getRandomId(),
+      publicKey: exported.publicKey,
+      privateKey: exported.privateKey,
+    });
+  }
+
+  return keys;
+};
+
+const createFreshDeviceState = async (userId: string): Promise<StoredSecureDeviceState> => {
+  const { deviceName, platform } = describeCurrentDevice();
+  const identityKeys = await generateSigningKeyPair();
+  const signedPreKey = await generateExchangeKeyPair();
+  const exportedIdentity = await exportPrivatePublicPair(identityKeys);
+  const exportedSignedPreKey = await exportPrivatePublicPair(signedPreKey);
+  const signature = await signSignedPreKey(identityKeys.privateKey, exportedSignedPreKey.publicKey);
+
+  return {
+    version: 1,
+    ownerUserId: userId,
+    deviceId: window.crypto.randomUUID(),
+    deviceName,
+    platform,
+    appVersion: ACTIVE_APP_VERSION,
+    algorithm: SUPPORTED_ALGORITHM,
+    registrationId: Number(getRandomId() % 16380) + 1,
+    identity: exportedIdentity,
+    signedPreKey: {
+      keyId: getRandomId(),
+      publicKey: exportedSignedPreKey.publicKey,
+      privateKey: exportedSignedPreKey.privateKey,
+      signature,
+    },
+    oneTimePreKeys: await generateOneTimePreKeys(),
+    lastServerSyncAt: null,
+  };
+};
+
+const shouldResync = (state: StoredSecureDeviceState) => {
+  if (!state.lastServerSyncAt) return true;
+
+  const lastSyncAt = new Date(state.lastServerSyncAt).getTime();
+  if (Number.isNaN(lastSyncAt)) return true;
+
+  return Date.now() - lastSyncAt > SYNC_INTERVAL_MS;
+};
+
+const buildPublicBundlePayload = (
+  state: StoredSecureDeviceState,
+): SecureDeviceBundlePayload => ({
+  algorithm: state.algorithm,
+  identityPublicKey: state.identity.publicKey,
+  signedPreKey: {
+    keyId: state.signedPreKey.keyId,
+    publicKey: state.signedPreKey.publicKey,
+    signature: state.signedPreKey.signature,
+  },
+  registrationId: state.registrationId,
+  oneTimePreKeys: state.oneTimePreKeys.map<PublicPreKey>((preKey) => ({
+    keyId: preKey.keyId,
+    publicKey: preKey.publicKey,
+  })),
+});
+
+const registerBundle = async (token: string, state: StoredSecureDeviceState) => {
+  if (!baseUrl) {
+    throw new Error("NEXT_PUBLIC_API_URL is not configured");
+  }
+
+  const response = await fetch(`${baseUrl}/e2ee/devices/register`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      deviceId: state.deviceId,
+      deviceName: state.deviceName,
+      platform: state.platform,
+      appVersion: state.appVersion,
+      bundle: buildPublicBundlePayload(state),
+    }),
+  });
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null);
+    const message = payload?.message || "Failed to register secure device";
+    throw Object.assign(new Error(message), { statusCode: response.status });
+  }
+};
+
+export const ensureRegisteredSecureDevice = async ({
+  token,
+  userId,
+}: {
+  token: string;
+  userId: string;
+}) => {
+  if (typeof window === "undefined" || !window.crypto?.subtle) {
+    return null;
+  }
+
+  let state = await getStoredSecureDeviceState();
+
+  if (!state || state.ownerUserId !== userId) {
+    if (state && state.ownerUserId !== userId) {
+      await clearStoredSecureDeviceState();
+    }
+    state = await createFreshDeviceState(userId);
+    await saveStoredSecureDeviceState(state);
+  }
+
+  if (!shouldResync(state)) {
+    return state;
+  }
+
+  try {
+    await registerBundle(token, state);
+    const nextState: StoredSecureDeviceState = {
+      ...state,
+      lastServerSyncAt: new Date().toISOString(),
+    };
+    await saveStoredSecureDeviceState(nextState);
+    return nextState;
+  } catch (error: any) {
+    if (error?.statusCode === 409) {
+      const regenerated = await createFreshDeviceState(userId);
+      await registerBundle(token, regenerated);
+      const nextState: StoredSecureDeviceState = {
+        ...regenerated,
+        lastServerSyncAt: new Date().toISOString(),
+      };
+      await saveStoredSecureDeviceState(nextState);
+      return nextState;
+    }
+
+    console.error("Secure device bootstrap failed:", error);
+    return state;
+  }
+};

--- a/services/secureChatService.ts
+++ b/services/secureChatService.ts
@@ -1,0 +1,336 @@
+"use client";
+
+import baseUrl from "@/helpers/baseUrl";
+import { decryptSecureEnvelope, encryptSecureTextForRecipients } from "@/lib/e2ee/secureMessageCrypto";
+import { ensureRegisteredSecureDevice } from "@/services/e2eeDeviceService";
+import type { Conversation, Message, ReplyPreview } from "@/types/chat.types";
+import type {
+  PublicSecureDeviceBundle,
+  SecureEncryptedEnvelope,
+  StoredSecureDeviceState,
+} from "@/types/e2ee.types";
+
+const bundleCache = new Map<string, { cachedAt: number; devices: PublicSecureDeviceBundle[] }>();
+const BUNDLE_CACHE_TTL_MS = 60 * 1000;
+
+const getApiBaseUrl = () => {
+  if (!baseUrl) {
+    throw new Error("NEXT_PUBLIC_API_URL is not configured");
+  }
+
+  return baseUrl;
+};
+
+const fetchJson = async (input: RequestInfo | URL, init?: RequestInit) => {
+  const response = await fetch(input, init);
+  const payload = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    throw new Error(payload?.message || "Secure chat request failed");
+  }
+
+  return payload;
+};
+
+const getSecureDeviceState = async (token: string, userId: string) => {
+  const state = await ensureRegisteredSecureDevice({ token, userId });
+  if (!state) {
+    throw new Error("Secure device bootstrap is not available on this browser");
+  }
+
+  return state;
+};
+
+const getConversationRecipient = (conversation: Conversation, userId: string) => {
+  const recipient = conversation.participants.find((participant) => participant.userId !== userId);
+  if (!recipient) {
+    throw new Error("Unable to resolve the secure chat recipient");
+  }
+
+  return recipient.userId;
+};
+
+const fetchPublicDeviceBundles = async (token: string, userId: string) => {
+  const cacheKey = `bundles:${userId}`;
+  const cached = bundleCache.get(cacheKey);
+  if (cached && Date.now() - cached.cachedAt < BUNDLE_CACHE_TTL_MS) {
+    return cached.devices;
+  }
+
+  const payload = await fetchJson(`${getApiBaseUrl()}/e2ee/users/${userId}/device-bundles`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  const devices = (payload?.data || []).map((device: any) => ({
+    userId,
+    deviceId: device.deviceId,
+    deviceName: device.deviceName,
+    platform: device.platform,
+    bundle: device.bundle,
+    oneTimePreKeys: device.oneTimePreKeys || [],
+  })) as PublicSecureDeviceBundle[];
+
+  bundleCache.set(cacheKey, {
+    cachedAt: Date.now(),
+    devices,
+  });
+
+  return devices;
+};
+
+const decryptSecureApiMessage = async ({
+  rawMessage,
+  state,
+  token,
+}: {
+  rawMessage: any;
+  state: StoredSecureDeviceState;
+  token: string;
+}) => {
+  const envelope = rawMessage.encryptedEnvelope as SecureEncryptedEnvelope;
+  const senderDevices = await fetchPublicDeviceBundles(token, rawMessage.sender.id);
+  const senderDevice = senderDevices.find((device) => device.deviceId === envelope.senderDeviceId);
+
+  if (!senderDevice?.bundle?.identityPublicKey) {
+    throw new Error("Unable to resolve the sender secure identity");
+  }
+
+  const content = await decryptSecureEnvelope({
+    envelope,
+    senderIdentityPublicKey: senderDevice.bundle.identityPublicKey,
+    recipientState: state,
+  });
+
+  return {
+    id: rawMessage.id,
+    chatId: rawMessage.chatId,
+    content,
+    messageType: rawMessage.messageType,
+    replyToMessageId: rawMessage.replyToMessageId || null,
+    replyTo: null as ReplyPreview | null,
+    reactions: [],
+    status: rawMessage.status,
+    deliveredAt: rawMessage.deliveredAt || undefined,
+    readAt: rawMessage.readAt || undefined,
+    createdAt: rawMessage.createdAt,
+    sender: rawMessage.sender,
+    readBy: [],
+  } satisfies Message;
+};
+
+export const fetchSecureChatMessages = async ({
+  token,
+  userId,
+  chatId,
+  page = 1,
+  limit = 50,
+}: {
+  token: string;
+  userId: string;
+  chatId: string;
+  page?: number;
+  limit?: number;
+}) => {
+  const state = await getSecureDeviceState(token, userId);
+  const payload = await fetchJson(
+    `${getApiBaseUrl()}/e2ee/chats/${chatId}/messages?page=${page}&limit=${limit}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "x-qc-device-id": state.deviceId,
+      },
+    },
+  );
+
+  const decryptedMessages = await Promise.all(
+    ((payload?.data?.messages as any[]) || []).map(async (rawMessage) => {
+      try {
+        return await decryptSecureApiMessage({ rawMessage, state, token });
+      } catch (error) {
+        console.error("Failed to decrypt secure message", error);
+        return {
+          id: rawMessage.id,
+          chatId: rawMessage.chatId,
+          content: "[Unable to decrypt secure message]",
+          messageType: rawMessage.messageType,
+          replyToMessageId: rawMessage.replyToMessageId || null,
+          replyTo: null,
+          reactions: [],
+          status: rawMessage.status,
+          deliveredAt: rawMessage.deliveredAt || undefined,
+          readAt: rawMessage.readAt || undefined,
+          createdAt: rawMessage.createdAt,
+          sender: rawMessage.sender,
+          readBy: [],
+        } satisfies Message;
+      }
+    }),
+  );
+
+  return decryptedMessages.reverse();
+};
+
+export const createOrGetSecureDmChat = async ({
+  token,
+  participantId,
+}: {
+  token: string;
+  participantId: string;
+}) => {
+  const payload = await fetchJson(`${getApiBaseUrl()}/e2ee/dms`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      participantId,
+    }),
+  });
+
+  return payload?.data as {
+    chatId: string;
+    securityMode: "secure_dm_v1";
+    protocolVersion: string | null;
+  };
+};
+
+export const createOrGetLegacyDmChat = async ({
+  token,
+  participantId,
+}: {
+  token: string;
+  participantId: string;
+}) => {
+  const payload = await fetchJson(`${getApiBaseUrl()}/chats/dm`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      participantId,
+    }),
+  });
+
+  return payload?.data as {
+    chatId: string;
+    securityMode?: "legacy" | "secure_dm_v1";
+    protocolVersion?: string | null;
+  };
+};
+
+export const createOrGetPreferredDmChat = async ({
+  token,
+  participantId,
+}: {
+  token: string;
+  participantId: string;
+}) => {
+  try {
+    const secureChat = await createOrGetSecureDmChat({
+      token,
+      participantId,
+    });
+
+    return {
+      ...secureChat,
+      usedSecure: true,
+    };
+  } catch (secureError) {
+    console.warn("Secure DM unavailable, falling back to legacy DM", secureError);
+
+    const legacyChat = await createOrGetLegacyDmChat({
+      token,
+      participantId,
+    });
+
+    return {
+      ...legacyChat,
+      securityMode: legacyChat.securityMode || "legacy",
+      protocolVersion: legacyChat.protocolVersion || null,
+      usedSecure: legacyChat.securityMode === "secure_dm_v1",
+    };
+  }
+};
+
+export const sendSecureTextMessage = async ({
+  token,
+  userId,
+  chatId,
+  conversation,
+  content,
+  replyToMessageId,
+}: {
+  token: string;
+  userId: string;
+  chatId: string;
+  conversation: Conversation;
+  content: string;
+  replyToMessageId?: string;
+}) => {
+  const state = await getSecureDeviceState(token, userId);
+  const recipientUserId = getConversationRecipient(conversation, userId);
+  const [senderDevices, recipientDevices] = await Promise.all([
+    fetchPublicDeviceBundles(token, userId),
+    fetchPublicDeviceBundles(token, recipientUserId),
+  ]);
+
+  const { recipientPayloads } = await encryptSecureTextForRecipients({
+    content,
+    senderUserId: userId,
+    senderState: state,
+    recipientDevices: [...senderDevices, ...recipientDevices],
+  });
+
+  const payload = await fetchJson(`${getApiBaseUrl()}/e2ee/chats/${chatId}/messages`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+      "x-qc-device-id": state.deviceId,
+    },
+    body: JSON.stringify({
+      messageType: "text",
+      replyToMessageId: replyToMessageId || null,
+      recipientPayloads,
+    }),
+  });
+
+  bundleCache.delete(`bundles:${userId}`);
+
+  return {
+    id: payload.data.id,
+    chatId,
+    content,
+    messageType: "text",
+    replyToMessageId: replyToMessageId || null,
+    replyTo: null,
+    reactions: [],
+    status: payload.data.status || "sent",
+    createdAt: payload.data.createdAt,
+    sender: payload.data.sender,
+    readBy: [],
+  } satisfies Message;
+};
+
+export const markSecureChatAsRead = async ({
+  token,
+  userId,
+  chatId,
+}: {
+  token: string;
+  userId: string;
+  chatId: string;
+}) => {
+  const state = await getSecureDeviceState(token, userId);
+  await fetchJson(`${getApiBaseUrl()}/e2ee/chats/${chatId}/read`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "x-qc-device-id": state.deviceId,
+    },
+  });
+};

--- a/services/socketService.ts
+++ b/services/socketService.ts
@@ -223,12 +223,28 @@ class SocketService {
         }
     }
 
+    onSecureMessageAvailable(callback: (message: any) => void) {
+        if (this.socket) {
+            this.socket.on("secure_message_available", callback)
+        }
+    }
+
     offNewMessage(callback?: (message: any) => void) {
         if (this.socket) {
             if (callback) {
                 this.socket.off("new_message", callback)
             } else {
                 this.socket.off("new_message")
+            }
+        }
+    }
+
+    offSecureMessageAvailable(callback?: (message: any) => void) {
+        if (this.socket) {
+            if (callback) {
+                this.socket.off("secure_message_available", callback)
+            } else {
+                this.socket.off("secure_message_available")
             }
         }
     }

--- a/types/chat.types.ts
+++ b/types/chat.types.ts
@@ -1,6 +1,7 @@
 export type MessageType = "text" | "image" | "file" | "money" | "audio" | "video" | "document";
 export type MessageStatus = "sent" | "delivered" | "read";
 export type ChatType = "dm" | "group" | "support";
+export type ChatSecurityMode = "legacy" | "secure_dm_v1" | "secure_group_v1" | "support_plain";
 
 export interface User {
   id: string;
@@ -38,6 +39,8 @@ export interface Conversation {
   name?: string; // Make optional to match Chat interface
   isGroup: boolean;
   type?: ChatType;
+  securityMode?: ChatSecurityMode;
+  protocolVersion?: string | null;
   groupId?: string; // The actual group ID for group chats
   lastMessage?: LastMessage | null;
   timestamp?: string;
@@ -55,6 +58,8 @@ export interface Chat {
   name?: string; // Optional since DM chats might not have names
   isGroup: boolean;
   type?: ChatType;
+  securityMode?: ChatSecurityMode;
+  protocolVersion?: string | null;
   groupId?: string; // The actual group ID for group chats
   avatar?: string;
   participants: Participant[];

--- a/types/e2ee.types.ts
+++ b/types/e2ee.types.ts
@@ -1,0 +1,84 @@
+export type SupportedE2EEAlgorithm = "qc-e2ee-p256-v1";
+
+export interface PublicPreKey {
+  keyId: number;
+  publicKey: JsonWebKey;
+}
+
+export interface SecureDeviceBundlePayload {
+  algorithm: SupportedE2EEAlgorithm;
+  identityPublicKey: JsonWebKey;
+  signedPreKey: {
+    keyId: number;
+    publicKey: JsonWebKey;
+    signature: string;
+  };
+  registrationId: number;
+  oneTimePreKeys: PublicPreKey[];
+}
+
+export interface StoredOneTimePreKey extends PublicPreKey {
+  privateKey: JsonWebKey;
+}
+
+export interface StoredSecureDeviceState {
+  version: 1;
+  ownerUserId: string;
+  deviceId: string;
+  deviceName: string;
+  platform: string;
+  appVersion: string;
+  algorithm: SupportedE2EEAlgorithm;
+  registrationId: number;
+  identity: {
+    publicKey: JsonWebKey;
+    privateKey: JsonWebKey;
+  };
+  signedPreKey: {
+    keyId: number;
+    publicKey: JsonWebKey;
+    privateKey: JsonWebKey;
+    signature: string;
+  };
+  oneTimePreKeys: StoredOneTimePreKey[];
+  lastServerSyncAt?: string | null;
+}
+
+export interface PublicSecureDeviceBundle {
+  userId: string;
+  deviceId: string;
+  deviceName?: string;
+  platform?: string;
+  bundle: {
+    algorithm: SupportedE2EEAlgorithm;
+    identityPublicKey: JsonWebKey;
+    signedPreKeyId: number;
+    signedPreKeyPublic: JsonWebKey;
+    signedPreKeySignature: string;
+    registrationId: number;
+  };
+  oneTimePreKeys: PublicPreKey[];
+}
+
+export interface SecureEncryptedEnvelope {
+  version: 1;
+  protocolVersion: "secure-dm-v1";
+  algorithm: SupportedE2EEAlgorithm;
+  senderUserId: string;
+  senderDeviceId: string;
+  recipientUserId: string;
+  recipientDeviceId: string;
+  ephemeralPublicKey: JsonWebKey;
+  wrappedMessageKey: string;
+  wrappedMessageKeyIv: string;
+  ciphertext: string;
+  ciphertextIv: string;
+  createdAt: string;
+  signature: string;
+}
+
+export interface SecureRecipientPayload {
+  recipientUserId: string;
+  recipientDeviceId: string;
+  encryptedEnvelope: SecureEncryptedEnvelope;
+}


### PR DESCRIPTION
## Summary
Add the frontend foundation for `secure_dm_v1`.

## Included
- secure device bootstrap on authenticated clients
- local WebCrypto-based secure message encrypt/decrypt flow for text-only DMs
- secure chat fetch/send/read client services
- secure socket awareness for `secure_message_available`
- explicit UI entry points for secure chat
- preferred secure-first DM opening with legacy fallback from key entry points

## Notes
- this is a foundation PR, not the final secure chat rollout
- legacy chat remains intact
- secure DMs still depend on the matching backend foundation branch
- build validated locally with `npm run build`

## Follow-up
- integrate and deploy matching backend secure branch
- run end-to-end secure DM testing on deployed environments
- decide rollout UX and migration path for existing legacy DMs
